### PR TITLE
Adapting Klend analytics to release 1.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,164 @@
+.DS_STORE
+*.DS_STORE
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ external_klend_fetch_data.ipynb
 
 Kamino Lend IDL:
 kamino_lending.json
+
+#### Changelog
+Updated codegen_lend to work with the IDL of release 1.6.2

--- a/codegen_lend/accounts/__init__.py
+++ b/codegen_lend/accounts/__init__.py
@@ -1,7 +1,8 @@
+from .user_state import UserState, UserStateJSON
 from .lending_market import LendingMarket, LendingMarketJSON
 from .obligation import Obligation, ObligationJSON
-from .referrer_token_state import ReferrerTokenState, ReferrerTokenStateJSON
-from .user_metadata import UserMetadata, UserMetadataJSON
 from .referrer_state import ReferrerState, ReferrerStateJSON
+from .referrer_token_state import ReferrerTokenState, ReferrerTokenStateJSON
 from .short_url import ShortUrl, ShortUrlJSON
+from .user_metadata import UserMetadata, UserMetadataJSON
 from .reserve import Reserve, ReserveJSON

--- a/codegen_lend/accounts/lending_market.py
+++ b/codegen_lend/accounts/lending_market.py
@@ -8,24 +8,8 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-import codegen_lend.lend_types as types
-
-# Changing this to work for release 1.6.2
-
-"""
-Changelog: 
-#adding
-autodeleverage_enabled: u8,
-borrow_disabled: u8,
-min_net_value_in_obligation_sf: u128,
-min_value_skip_liquidation_ltv_bf_checks: u64,
-
-#Changing
-min_full_liquidation_amount_threshold -> min_full_liquidation_value_threshold 
-padding1 -> 177
-remove reserved
-"""
+from ..program_id import PROGRAM_ID
+from .. import types
 
 
 class LendingMarketJSON(typing.TypedDict):
@@ -49,7 +33,6 @@ class LendingMarketJSON(typing.TypedDict):
     multiplier_points_tag_boost: list[int]
     elevation_groups: list[types.elevation_group.ElevationGroupJSON]
     elevation_group_padding: list[int]
-
     min_net_value_in_obligation_sf: int
     min_value_skip_liquidation_ltv_bf_checks: int
     padding1: list[int]

--- a/codegen_lend/accounts/lending_market.py
+++ b/codegen_lend/accounts/lending_market.py
@@ -11,6 +11,22 @@ from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 import codegen_lend.lend_types as types
 
+# Changing this to work for release 1.6.2
+
+"""
+Changelog: 
+#adding
+autodeleverage_enabled: u8,
+borrow_disabled: u8,
+min_net_value_in_obligation_sf: u128,
+min_value_skip_liquidation_ltv_bf_checks: u64,
+
+#Changing
+min_full_liquidation_amount_threshold -> min_full_liquidation_value_threshold 
+padding1 -> 177
+remove reserved
+"""
+
 
 class LendingMarketJSON(typing.TypedDict):
     version: int
@@ -20,11 +36,12 @@ class LendingMarketJSON(typing.TypedDict):
     quote_currency: list[int]
     referral_fee_bps: int
     emergency_mode: int
-    reserved: list[int]
+    autodeleverage_enabled: int
+    borrow_disabled: int
     price_refresh_trigger_to_max_age_pct: int
     liquidation_max_debt_close_factor_pct: int
     insolvency_risk_unhealthy_ltv_pct: int
-    min_full_liquidation_amount_threshold: int
+    min_full_liquidation_value_threshold: int
     max_liquidatable_debt_market_value_at_once: int
     global_unhealthy_borrow_value: int
     global_allowed_borrow_value: int
@@ -32,6 +49,9 @@ class LendingMarketJSON(typing.TypedDict):
     multiplier_points_tag_boost: list[int]
     elevation_groups: list[types.elevation_group.ElevationGroupJSON]
     elevation_group_padding: list[int]
+
+    min_net_value_in_obligation_sf: int
+    min_value_skip_liquidation_ltv_bf_checks: int
     padding1: list[int]
 
 
@@ -46,11 +66,12 @@ class LendingMarket:
         "quote_currency" / borsh.U8[32],
         "referral_fee_bps" / borsh.U16,
         "emergency_mode" / borsh.U8,
-        "reserved" / borsh.U8[2],
+        "autodeleverage_enabled" / borsh.U8,
+        "borrow_disabled" / borsh.U8,
         "price_refresh_trigger_to_max_age_pct" / borsh.U8,
         "liquidation_max_debt_close_factor_pct" / borsh.U8,
         "insolvency_risk_unhealthy_ltv_pct" / borsh.U8,
-        "min_full_liquidation_amount_threshold" / borsh.U64,
+        "min_full_liquidation_value_threshold" / borsh.U64,
         "max_liquidatable_debt_market_value_at_once" / borsh.U64,
         "global_unhealthy_borrow_value" / borsh.U64,
         "global_allowed_borrow_value" / borsh.U64,
@@ -58,7 +79,9 @@ class LendingMarket:
         "multiplier_points_tag_boost" / borsh.U8[8],
         "elevation_groups" / types.elevation_group.ElevationGroup.layout[32],
         "elevation_group_padding" / borsh.U64[90],
-        "padding1" / borsh.U64[180],
+        "min_net_value_in_obligation_sf" / borsh.U128,
+        "min_value_skip_liquidation_ltv_bf_checks" / borsh.U64,
+        "padding1" / borsh.U64[177],
     )
     version: int
     bump_seed: int
@@ -67,11 +90,12 @@ class LendingMarket:
     quote_currency: list[int]
     referral_fee_bps: int
     emergency_mode: int
-    reserved: list[int]
+    autodeleverage_enabled: int
+    borrow_disabled: int
     price_refresh_trigger_to_max_age_pct: int
     liquidation_max_debt_close_factor_pct: int
     insolvency_risk_unhealthy_ltv_pct: int
-    min_full_liquidation_amount_threshold: int
+    min_full_liquidation_value_threshold: int
     max_liquidatable_debt_market_value_at_once: int
     global_unhealthy_borrow_value: int
     global_allowed_borrow_value: int
@@ -79,6 +103,8 @@ class LendingMarket:
     multiplier_points_tag_boost: list[int]
     elevation_groups: list[types.elevation_group.ElevationGroup]
     elevation_group_padding: list[int]
+    min_net_value_in_obligation_sf: int
+    min_value_skip_liquidation_ltv_bf_checks: int
     padding1: list[int]
 
     @classmethod
@@ -132,11 +158,12 @@ class LendingMarket:
             quote_currency=dec.quote_currency,
             referral_fee_bps=dec.referral_fee_bps,
             emergency_mode=dec.emergency_mode,
-            reserved=dec.reserved,
+            autodeleverage_enabled=dec.autodeleverage_enabled,
+            borrow_disabled=dec.borrow_disabled,
             price_refresh_trigger_to_max_age_pct=dec.price_refresh_trigger_to_max_age_pct,
             liquidation_max_debt_close_factor_pct=dec.liquidation_max_debt_close_factor_pct,
             insolvency_risk_unhealthy_ltv_pct=dec.insolvency_risk_unhealthy_ltv_pct,
-            min_full_liquidation_amount_threshold=dec.min_full_liquidation_amount_threshold,
+            min_full_liquidation_value_threshold=dec.min_full_liquidation_value_threshold,
             max_liquidatable_debt_market_value_at_once=dec.max_liquidatable_debt_market_value_at_once,
             global_unhealthy_borrow_value=dec.global_unhealthy_borrow_value,
             global_allowed_borrow_value=dec.global_allowed_borrow_value,
@@ -151,6 +178,8 @@ class LendingMarket:
                 )
             ),
             elevation_group_padding=dec.elevation_group_padding,
+            min_net_value_in_obligation_sf=dec.min_net_value_in_obligation_sf,
+            min_value_skip_liquidation_ltv_bf_checks=dec.min_value_skip_liquidation_ltv_bf_checks,
             padding1=dec.padding1,
         )
 
@@ -163,11 +192,12 @@ class LendingMarket:
             "quote_currency": self.quote_currency,
             "referral_fee_bps": self.referral_fee_bps,
             "emergency_mode": self.emergency_mode,
-            "reserved": self.reserved,
+            "autodeleverage_enabled": self.autodeleverage_enabled,
+            "borrow_disabled": self.borrow_disabled,
             "price_refresh_trigger_to_max_age_pct": self.price_refresh_trigger_to_max_age_pct,
             "liquidation_max_debt_close_factor_pct": self.liquidation_max_debt_close_factor_pct,
             "insolvency_risk_unhealthy_ltv_pct": self.insolvency_risk_unhealthy_ltv_pct,
-            "min_full_liquidation_amount_threshold": self.min_full_liquidation_amount_threshold,
+            "min_full_liquidation_value_threshold": self.min_full_liquidation_value_threshold,
             "max_liquidatable_debt_market_value_at_once": self.max_liquidatable_debt_market_value_at_once,
             "global_unhealthy_borrow_value": self.global_unhealthy_borrow_value,
             "global_allowed_borrow_value": self.global_allowed_borrow_value,
@@ -177,6 +207,8 @@ class LendingMarket:
                 map(lambda item: item.to_json(), self.elevation_groups)
             ),
             "elevation_group_padding": self.elevation_group_padding,
+            "min_net_value_in_obligation_sf": self.min_net_value_in_obligation_sf,
+            "min_value_skip_liquidation_ltv_bf_checks": self.min_value_skip_liquidation_ltv_bf_checks,
             "padding1": self.padding1,
         }
 
@@ -192,7 +224,8 @@ class LendingMarket:
             quote_currency=obj["quote_currency"],
             referral_fee_bps=obj["referral_fee_bps"],
             emergency_mode=obj["emergency_mode"],
-            reserved=obj["reserved"],
+            autodeleverage_enabled=obj["autodeleverage_enabled"],
+            borrow_disabled=obj["borrow_disabled"],
             price_refresh_trigger_to_max_age_pct=obj[
                 "price_refresh_trigger_to_max_age_pct"
             ],
@@ -200,8 +233,8 @@ class LendingMarket:
                 "liquidation_max_debt_close_factor_pct"
             ],
             insolvency_risk_unhealthy_ltv_pct=obj["insolvency_risk_unhealthy_ltv_pct"],
-            min_full_liquidation_amount_threshold=obj[
-                "min_full_liquidation_amount_threshold"
+            min_full_liquidation_value_threshold=obj[
+                "min_full_liquidation_value_threshold"
             ],
             max_liquidatable_debt_market_value_at_once=obj[
                 "max_liquidatable_debt_market_value_at_once"
@@ -217,5 +250,9 @@ class LendingMarket:
                 )
             ),
             elevation_group_padding=obj["elevation_group_padding"],
+            min_net_value_in_obligation_sf=obj["min_net_value_in_obligation_sf"],
+            min_value_skip_liquidation_ltv_bf_checks=obj[
+                "min_value_skip_liquidation_ltv_bf_checks"
+            ],
             padding1=obj["padding1"],
         )

--- a/codegen_lend/accounts/obligation.py
+++ b/codegen_lend/accounts/obligation.py
@@ -8,19 +8,8 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-import codegen_lend.lend_types as types
-
-# Updating for release 1.6.2
-
-"""
-Changelog
-Added:
-num_of_obsolete_reserves
-has_debt
-borrowing_disabled
-highest_borrow_factor_pct
-"""
+from ..program_id import PROGRAM_ID
+from .. import types
 
 
 class ObligationJSON(typing.TypedDict):
@@ -29,15 +18,13 @@ class ObligationJSON(typing.TypedDict):
     lending_market: str
     owner: str
     deposits: list[types.obligation_collateral.ObligationCollateralJSON]
-    lowest_reserve_deposit_ltv: int
+    lowest_reserve_deposit_liquidation_ltv: int
     deposited_value_sf: int
-
     borrows: list[types.obligation_liquidity.ObligationLiquidityJSON]
     borrow_factor_adjusted_debt_value_sf: int
     borrowed_assets_market_value_sf: int
     allowed_borrow_value_sf: int
     unhealthy_borrow_value_sf: int
-
     deposits_asset_tiers: list[int]
     borrows_asset_tiers: list[int]
     elevation_group: int
@@ -82,18 +69,15 @@ class Obligation:
     lending_market: Pubkey
     owner: Pubkey
     deposits: list[types.obligation_collateral.ObligationCollateral]
-    lowest_reserve_deposit_ltv: int
+    lowest_reserve_deposit_liquidation_ltv: int
     deposited_value_sf: int
-
     borrows: list[types.obligation_liquidity.ObligationLiquidity]
     borrow_factor_adjusted_debt_value_sf: int
     borrowed_assets_market_value_sf: int
     allowed_borrow_value_sf: int
     unhealthy_borrow_value_sf: int
-
     deposits_asset_tiers: list[int]
     borrows_asset_tiers: list[int]
-
     elevation_group: int
     num_of_obsolete_reserves: int
     has_debt: int
@@ -159,7 +143,7 @@ class Obligation:
                     dec.deposits,
                 )
             ),
-            lowest_reserve_deposit_ltv=dec.lowest_reserve_deposit_ltv,
+            lowest_reserve_deposit_liquidation_ltv=dec.lowest_reserve_deposit_liquidation_ltv,
             deposited_value_sf=dec.deposited_value_sf,
             borrows=list(
                 map(
@@ -192,7 +176,7 @@ class Obligation:
             "lending_market": str(self.lending_market),
             "owner": str(self.owner),
             "deposits": list(map(lambda item: item.to_json(), self.deposits)),
-            "lowest_reserve_deposit_ltv": self.lowest_reserve_deposit_ltv,
+            "lowest_reserve_deposit_liquidation_ltv": self.lowest_reserve_deposit_liquidation_ltv,
             "deposited_value_sf": self.deposited_value_sf,
             "borrows": list(map(lambda item: item.to_json(), self.borrows)),
             "borrow_factor_adjusted_debt_value_sf": self.borrow_factor_adjusted_debt_value_sf,
@@ -226,7 +210,9 @@ class Obligation:
                     obj["deposits"],
                 )
             ),
-            lowest_reserve_deposit_ltv=obj["lowest_reserve_deposit_ltv"],
+            lowest_reserve_deposit_liquidation_ltv=obj[
+                "lowest_reserve_deposit_liquidation_ltv"
+            ],
             deposited_value_sf=obj["deposited_value_sf"],
             borrows=list(
                 map(

--- a/codegen_lend/accounts/obligation.py
+++ b/codegen_lend/accounts/obligation.py
@@ -11,6 +11,17 @@ from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 import codegen_lend.lend_types as types
 
+# Updating for release 1.6.2
+
+"""
+Changelog
+Added:
+num_of_obsolete_reserves
+has_debt
+borrowing_disabled
+highest_borrow_factor_pct
+"""
+
 
 class ObligationJSON(typing.TypedDict):
     tag: int
@@ -20,16 +31,22 @@ class ObligationJSON(typing.TypedDict):
     deposits: list[types.obligation_collateral.ObligationCollateralJSON]
     lowest_reserve_deposit_ltv: int
     deposited_value_sf: int
+
     borrows: list[types.obligation_liquidity.ObligationLiquidityJSON]
     borrow_factor_adjusted_debt_value_sf: int
     borrowed_assets_market_value_sf: int
     allowed_borrow_value_sf: int
     unhealthy_borrow_value_sf: int
+
     deposits_asset_tiers: list[int]
     borrows_asset_tiers: list[int]
     elevation_group: int
-    reserved: list[int]
+    num_of_obsolete_reserves: int
+    has_debt: int
     referrer: str
+    borrowing_disabled: int
+    reserved: list[int]
+    highest_borrow_factor_pct: int
     padding3: list[int]
 
 
@@ -42,7 +59,7 @@ class Obligation:
         "lending_market" / BorshPubkey,
         "owner" / BorshPubkey,
         "deposits" / types.obligation_collateral.ObligationCollateral.layout[8],
-        "lowest_reserve_deposit_ltv" / borsh.U64,
+        "lowest_reserve_deposit_liquidation_ltv" / borsh.U64,
         "deposited_value_sf" / borsh.U128,
         "borrows" / types.obligation_liquidity.ObligationLiquidity.layout[5],
         "borrow_factor_adjusted_debt_value_sf" / borsh.U128,
@@ -52,9 +69,13 @@ class Obligation:
         "deposits_asset_tiers" / borsh.U8[8],
         "borrows_asset_tiers" / borsh.U8[5],
         "elevation_group" / borsh.U8,
-        "reserved" / borsh.U8[2],
+        "num_of_obsolete_reserves" / borsh.U8,
+        "has_debt" / borsh.U8,
         "referrer" / BorshPubkey,
-        "padding3" / borsh.U64[128],
+        "borrowing_disabled" / borsh.U8,
+        "reserved" / borsh.U8[7],
+        "highest_borrow_factor_pct" / borsh.U64,
+        "padding3" / borsh.U64[126],
     )
     tag: int
     last_update: types.last_update.LastUpdate
@@ -63,16 +84,23 @@ class Obligation:
     deposits: list[types.obligation_collateral.ObligationCollateral]
     lowest_reserve_deposit_ltv: int
     deposited_value_sf: int
+
     borrows: list[types.obligation_liquidity.ObligationLiquidity]
     borrow_factor_adjusted_debt_value_sf: int
     borrowed_assets_market_value_sf: int
     allowed_borrow_value_sf: int
     unhealthy_borrow_value_sf: int
+
     deposits_asset_tiers: list[int]
     borrows_asset_tiers: list[int]
+
     elevation_group: int
-    reserved: list[int]
+    num_of_obsolete_reserves: int
+    has_debt: int
     referrer: Pubkey
+    borrowing_disabled: int
+    reserved: list[int]
+    highest_borrow_factor_pct: int
     padding3: list[int]
 
     @classmethod
@@ -148,8 +176,12 @@ class Obligation:
             deposits_asset_tiers=dec.deposits_asset_tiers,
             borrows_asset_tiers=dec.borrows_asset_tiers,
             elevation_group=dec.elevation_group,
-            reserved=dec.reserved,
+            num_of_obsolete_reserves=dec.num_of_obsolete_reserves,
+            has_debt=dec.has_debt,
             referrer=dec.referrer,
+            borrowing_disabled=dec.borrowing_disabled,
+            reserved=dec.reserved,
+            highest_borrow_factor_pct=dec.highest_borrow_factor_pct,
             padding3=dec.padding3,
         )
 
@@ -170,8 +202,12 @@ class Obligation:
             "deposits_asset_tiers": self.deposits_asset_tiers,
             "borrows_asset_tiers": self.borrows_asset_tiers,
             "elevation_group": self.elevation_group,
-            "reserved": self.reserved,
+            "num_of_obsolete_reserves": self.num_of_obsolete_reserves,
+            "has_debt": self.has_debt,
             "referrer": str(self.referrer),
+            "borrowing_disabled": self.borrowing_disabled,
+            "reserved": self.reserved,
+            "highest_borrow_factor_pct": self.highest_borrow_factor_pct,
             "padding3": self.padding3,
         }
 
@@ -209,7 +245,11 @@ class Obligation:
             deposits_asset_tiers=obj["deposits_asset_tiers"],
             borrows_asset_tiers=obj["borrows_asset_tiers"],
             elevation_group=obj["elevation_group"],
-            reserved=obj["reserved"],
+            num_of_obsolete_reserves=obj["num_of_obsolete_reserves"],
+            has_debt=obj["has_debt"],
             referrer=Pubkey.from_string(obj["referrer"]),
+            borrowing_disabled=obj["borrowing_disabled"],
+            reserved=obj["reserved"],
+            highest_borrow_factor_pct=obj["highest_borrow_factor_pct"],
             padding3=obj["padding3"],
         )

--- a/codegen_lend/accounts/referrer_state.py
+++ b/codegen_lend/accounts/referrer_state.py
@@ -8,13 +8,7 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-
-# Change Log: Updating this to keep track with the update to Klend program release 1.6.2
-
-"""
-owner: Pubkey,
-"""
+from ..program_id import PROGRAM_ID
 
 
 class ReferrerStateJSON(typing.TypedDict):
@@ -74,10 +68,16 @@ class ReferrerState:
                 "The discriminator for this account is invalid"
             )
         dec = ReferrerState.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
-        return cls(short_url=dec.short_url, owner=dec.owner)
+        return cls(
+            short_url=dec.short_url,
+            owner=dec.owner,
+        )
 
     def to_json(self) -> ReferrerStateJSON:
-        return {"short_url": str(self.short_url), "owner": str(self.owner)}
+        return {
+            "short_url": str(self.short_url),
+            "owner": str(self.owner),
+        }
 
     @classmethod
     def from_json(cls, obj: ReferrerStateJSON) -> "ReferrerState":

--- a/codegen_lend/accounts/referrer_state.py
+++ b/codegen_lend/accounts/referrer_state.py
@@ -10,16 +10,26 @@ from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 
+# Change Log: Updating this to keep track with the update to Klend program release 1.6.2
+
+"""
+owner: Pubkey,
+"""
+
 
 class ReferrerStateJSON(typing.TypedDict):
     short_url: str
+    owner: str
 
 
 @dataclass
 class ReferrerState:
     discriminator: typing.ClassVar = b"\xc2Q\xd9g\x0c\x13\x0cB"
-    layout: typing.ClassVar = borsh.CStruct("short_url" / BorshPubkey)
+    layout: typing.ClassVar = borsh.CStruct(
+        "short_url" / BorshPubkey, "owner" / BorshPubkey
+    )
     short_url: Pubkey
+    owner: Pubkey
 
     @classmethod
     async def fetch(
@@ -64,17 +74,14 @@ class ReferrerState:
                 "The discriminator for this account is invalid"
             )
         dec = ReferrerState.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
-        return cls(
-            short_url=dec.short_url,
-        )
+        return cls(short_url=dec.short_url, owner=dec.owner)
 
     def to_json(self) -> ReferrerStateJSON:
-        return {
-            "short_url": str(self.short_url),
-        }
+        return {"short_url": str(self.short_url), "owner": str(self.owner)}
 
     @classmethod
     def from_json(cls, obj: ReferrerStateJSON) -> "ReferrerState":
         return cls(
             short_url=Pubkey.from_string(obj["short_url"]),
+            owner=Pubkey.from_string(obj["owner"]),
         )

--- a/codegen_lend/accounts/referrer_token_state.py
+++ b/codegen_lend/accounts/referrer_token_state.py
@@ -8,10 +8,7 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-
-# Changing this to adapt to Release 1.6.2
-# Nothing changed
+from ..program_id import PROGRAM_ID
 
 
 class ReferrerTokenStateJSON(typing.TypedDict):

--- a/codegen_lend/accounts/referrer_token_state.py
+++ b/codegen_lend/accounts/referrer_token_state.py
@@ -10,6 +10,9 @@ from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 
+# Changing this to adapt to Release 1.6.2
+# Nothing changed
+
 
 class ReferrerTokenStateJSON(typing.TypedDict):
     referrer: str

--- a/codegen_lend/accounts/reserve.py
+++ b/codegen_lend/accounts/reserve.py
@@ -11,25 +11,45 @@ from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 import codegen_lend.lend_types as types
 
+# Changing this to adapt to Release 1.6.2
 
+"""
+Added
+borrowed_amount_outside_elevation_group
+borrowed_amounts_against_this_reserve_in_elevation_groups
+changing padding length
+"""
+
+
+# Done
+# TODO: check
 class ReserveJSON(typing.TypedDict):
     version: int
     last_update: types.last_update.LastUpdateJSON
     lending_market: str
+
     farm_collateral: str
     farm_debt: str
+
     liquidity: types.reserve_liquidity.ReserveLiquidityJSON
     reserve_liquidity_padding: list[int]
+
     collateral: types.reserve_collateral.ReserveCollateralJSON
     reserve_collateral_padding: list[int]
+
     config: types.reserve_config.ReserveConfigJSON
     config_padding: list[int]
+
+    borrowed_amount_outside_elevation_group: int
+    borrowed_amounts_against_this_reserve_in_elevation_groups: int
+
     padding: list[int]
 
 
 @dataclass
 class Reserve:
     discriminator: typing.ClassVar = b"+\xf2\xcc\xca\x1a\xf7;\x7f"
+
     layout: typing.ClassVar = borsh.CStruct(
         "version" / borsh.U64,
         "last_update" / types.last_update.LastUpdate.layout,
@@ -41,8 +61,10 @@ class Reserve:
         "collateral" / types.reserve_collateral.ReserveCollateral.layout,
         "reserve_collateral_padding" / borsh.U64[150],
         "config" / types.reserve_config.ReserveConfig.layout,
-        "config_padding" / borsh.U64[150],
-        "padding" / borsh.U64[240],
+        "config_padding" / borsh.U64[117],
+        "borrowed_amount_outside_elevation_group" / borsh.U64,
+        "borrowed_amounts_against_this_reserve_in_elevation_groups" / borsh.U64[32],
+        "padding" / borsh.U64[207],
     )
     version: int
     last_update: types.last_update.LastUpdate
@@ -55,6 +77,8 @@ class Reserve:
     reserve_collateral_padding: list[int]
     config: types.reserve_config.ReserveConfig
     config_padding: list[int]
+    borrowed_amount_outside_elevation_group: int
+    borrowed_amounts_against_this_reserve_in_elevation_groups: list[int]
     padding: list[int]
 
     @classmethod
@@ -116,6 +140,8 @@ class Reserve:
             reserve_collateral_padding=dec.reserve_collateral_padding,
             config=types.reserve_config.ReserveConfig.from_decoded(dec.config),
             config_padding=dec.config_padding,
+            borrowed_amount_outside_elevation_group=dec.borrowed_amount_outside_elevation_group,
+            borrowed_amounts_against_this_reserve_in_elevation_groups=dec.borrowed_amounts_against_this_reserve_in_elevation_groups,
             padding=dec.padding,
         )
 
@@ -132,6 +158,8 @@ class Reserve:
             "reserve_collateral_padding": self.reserve_collateral_padding,
             "config": self.config.to_json(),
             "config_padding": self.config_padding,
+            "borrowed_amount_outside_elevation_group": self.borrowed_amount_outside_elevation_group,
+            "borrowed_amounts_against_this_reserve_in_elevation_groups": self.borrowed_amounts_against_this_reserve_in_elevation_groups,
             "padding": self.padding,
         }
 
@@ -153,5 +181,11 @@ class Reserve:
             reserve_collateral_padding=obj["reserve_collateral_padding"],
             config=types.reserve_config.ReserveConfig.from_json(obj["config"]),
             config_padding=obj["config_padding"],
+            borrowed_amount_outside_elevation_group=obj[
+                "borrowed_amount_outside_elevation_group"
+            ],
+            borrowed_amounts_against_this_reserve_in_elevation_groups=obj[
+                "borrowed_amounts_against_this_reserve_in_elevation_groups"
+            ],
             padding=obj["padding"],
         )

--- a/codegen_lend/accounts/reserve.py
+++ b/codegen_lend/accounts/reserve.py
@@ -8,48 +8,30 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-import codegen_lend.lend_types as types
-
-# Changing this to adapt to Release 1.6.2
-
-"""
-Added
-borrowed_amount_outside_elevation_group
-borrowed_amounts_against_this_reserve_in_elevation_groups
-changing padding length
-"""
+from ..program_id import PROGRAM_ID
+from .. import types
 
 
-# Done
-# TODO: check
 class ReserveJSON(typing.TypedDict):
     version: int
     last_update: types.last_update.LastUpdateJSON
     lending_market: str
-
     farm_collateral: str
     farm_debt: str
-
     liquidity: types.reserve_liquidity.ReserveLiquidityJSON
     reserve_liquidity_padding: list[int]
-
     collateral: types.reserve_collateral.ReserveCollateralJSON
     reserve_collateral_padding: list[int]
-
     config: types.reserve_config.ReserveConfigJSON
     config_padding: list[int]
-
     borrowed_amount_outside_elevation_group: int
-    borrowed_amounts_against_this_reserve_in_elevation_groups: int
-
+    borrowed_amounts_against_this_reserve_in_elevation_groups: list[int]
     padding: list[int]
 
 
 @dataclass
 class Reserve:
     discriminator: typing.ClassVar = b"+\xf2\xcc\xca\x1a\xf7;\x7f"
-
     layout: typing.ClassVar = borsh.CStruct(
         "version" / borsh.U64,
         "last_update" / types.last_update.LastUpdate.layout,

--- a/codegen_lend/accounts/short_url.py
+++ b/codegen_lend/accounts/short_url.py
@@ -10,6 +10,10 @@ from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 
+# Changing this to adapt to Release 1.6.2
+
+# It does not need changing
+
 
 class ShortUrlJSON(typing.TypedDict):
     referrer: str

--- a/codegen_lend/accounts/short_url.py
+++ b/codegen_lend/accounts/short_url.py
@@ -8,11 +8,7 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-
-# Changing this to adapt to Release 1.6.2
-
-# It does not need changing
+from ..program_id import PROGRAM_ID
 
 
 class ShortUrlJSON(typing.TypedDict):

--- a/codegen_lend/accounts/user_metadata.py
+++ b/codegen_lend/accounts/user_metadata.py
@@ -10,11 +10,21 @@ from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
 from codegen_lend.program_id import PROGRAM_ID
 
+# Change Log: Updating this to keep track with the update to Klend program release 1.6.2
+
+"""
+adding:
+owner: Pubkey,
+changing
+padding_1: 55 -> 51
+"""
+
 
 class UserMetadataJSON(typing.TypedDict):
     referrer: str
     bump: int
     user_lookup_table: str
+    owner: str
     padding1: list[int]
     padding2: list[int]
 
@@ -26,12 +36,14 @@ class UserMetadata:
         "referrer" / BorshPubkey,
         "bump" / borsh.U64,
         "user_lookup_table" / BorshPubkey,
-        "padding1" / borsh.U64[55],
+        "owner" / BorshPubkey,
+        "padding1" / borsh.U64[51],
         "padding2" / borsh.U64[64],
     )
     referrer: Pubkey
     bump: int
     user_lookup_table: Pubkey
+    owner: Pubkey
     padding1: list[int]
     padding2: list[int]
 
@@ -82,6 +94,7 @@ class UserMetadata:
             referrer=dec.referrer,
             bump=dec.bump,
             user_lookup_table=dec.user_lookup_table,
+            owner=dec.owner,
             padding1=dec.padding1,
             padding2=dec.padding2,
         )
@@ -91,6 +104,7 @@ class UserMetadata:
             "referrer": str(self.referrer),
             "bump": self.bump,
             "user_lookup_table": str(self.user_lookup_table),
+            "owner": str(self.owner),
             "padding1": self.padding1,
             "padding2": self.padding2,
         }
@@ -101,6 +115,7 @@ class UserMetadata:
             referrer=Pubkey.from_string(obj["referrer"]),
             bump=obj["bump"],
             user_lookup_table=Pubkey.from_string(obj["user_lookup_table"]),
+            owner=Pubkey.from_string(obj["owner"]),
             padding1=obj["padding1"],
             padding2=obj["padding2"],
         )

--- a/codegen_lend/accounts/user_metadata.py
+++ b/codegen_lend/accounts/user_metadata.py
@@ -8,16 +8,7 @@ from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
 from anchorpy.error import AccountInvalidDiscriminator
 from anchorpy.utils.rpc import get_multiple_accounts
 from anchorpy.borsh_extension import BorshPubkey
-from codegen_lend.program_id import PROGRAM_ID
-
-# Change Log: Updating this to keep track with the update to Klend program release 1.6.2
-
-"""
-adding:
-owner: Pubkey,
-changing
-padding_1: 55 -> 51
-"""
+from ..program_id import PROGRAM_ID
 
 
 class UserMetadataJSON(typing.TypedDict):

--- a/codegen_lend/accounts/user_state.py
+++ b/codegen_lend/accounts/user_state.py
@@ -1,0 +1,178 @@
+import typing
+from dataclasses import dataclass
+from solders.pubkey import Pubkey
+from solana.rpc.async_api import AsyncClient
+from solana.rpc.commitment import Commitment
+import borsh_construct as borsh
+from anchorpy.coder.accounts import ACCOUNT_DISCRIMINATOR_SIZE
+from anchorpy.error import AccountInvalidDiscriminator
+from anchorpy.utils.rpc import get_multiple_accounts
+from anchorpy.borsh_extension import BorshPubkey
+from ..program_id import PROGRAM_ID
+
+
+class UserStateJSON(typing.TypedDict):
+    user_id: int
+    farm_state: str
+    owner: str
+    is_farm_delegated: int
+    padding0: list[int]
+    rewards_tally_scaled: list[int]
+    rewards_issued_unclaimed: list[int]
+    last_claim_ts: list[int]
+    active_stake_scaled: int
+    pending_deposit_stake_scaled: int
+    pending_deposit_stake_ts: int
+    pending_withdrawal_unstake_scaled: int
+    pending_withdrawal_unstake_ts: int
+    bump: int
+    delegatee: str
+    last_stake_ts: int
+    padding1: list[int]
+
+
+@dataclass
+class UserState:
+    discriminator: typing.ClassVar = b"H\xb1U\xf9L\xa7\xba~"
+    layout: typing.ClassVar = borsh.CStruct(
+        "user_id" / borsh.U64,
+        "farm_state" / BorshPubkey,
+        "owner" / BorshPubkey,
+        "is_farm_delegated" / borsh.U8,
+        "padding0" / borsh.U8[7],
+        "rewards_tally_scaled" / borsh.U128[10],
+        "rewards_issued_unclaimed" / borsh.U64[10],
+        "last_claim_ts" / borsh.U64[10],
+        "active_stake_scaled" / borsh.U128,
+        "pending_deposit_stake_scaled" / borsh.U128,
+        "pending_deposit_stake_ts" / borsh.U64,
+        "pending_withdrawal_unstake_scaled" / borsh.U128,
+        "pending_withdrawal_unstake_ts" / borsh.U64,
+        "bump" / borsh.U64,
+        "delegatee" / BorshPubkey,
+        "last_stake_ts" / borsh.U64,
+        "padding1" / borsh.U64[50],
+    )
+    user_id: int
+    farm_state: Pubkey
+    owner: Pubkey
+    is_farm_delegated: int
+    padding0: list[int]
+    rewards_tally_scaled: list[int]
+    rewards_issued_unclaimed: list[int]
+    last_claim_ts: list[int]
+    active_stake_scaled: int
+    pending_deposit_stake_scaled: int
+    pending_deposit_stake_ts: int
+    pending_withdrawal_unstake_scaled: int
+    pending_withdrawal_unstake_ts: int
+    bump: int
+    delegatee: Pubkey
+    last_stake_ts: int
+    padding1: list[int]
+
+    @classmethod
+    async def fetch(
+        cls,
+        conn: AsyncClient,
+        address: Pubkey,
+        commitment: typing.Optional[Commitment] = None,
+        program_id: Pubkey = PROGRAM_ID,
+    ) -> typing.Optional["UserState"]:
+        resp = await conn.get_account_info(address, commitment=commitment)
+        info = resp.value
+        if info is None:
+            return None
+        if info.owner != program_id:
+            raise ValueError("Account does not belong to this program")
+        bytes_data = info.data
+        return cls.decode(bytes_data)
+
+    @classmethod
+    async def fetch_multiple(
+        cls,
+        conn: AsyncClient,
+        addresses: list[Pubkey],
+        commitment: typing.Optional[Commitment] = None,
+        program_id: Pubkey = PROGRAM_ID,
+    ) -> typing.List[typing.Optional["UserState"]]:
+        infos = await get_multiple_accounts(conn, addresses, commitment=commitment)
+        res: typing.List[typing.Optional["UserState"]] = []
+        for info in infos:
+            if info is None:
+                res.append(None)
+                continue
+            if info.account.owner != program_id:
+                raise ValueError("Account does not belong to this program")
+            res.append(cls.decode(info.account.data))
+        return res
+
+    @classmethod
+    def decode(cls, data: bytes) -> "UserState":
+        if data[:ACCOUNT_DISCRIMINATOR_SIZE] != cls.discriminator:
+            raise AccountInvalidDiscriminator(
+                "The discriminator for this account is invalid"
+            )
+        dec = UserState.layout.parse(data[ACCOUNT_DISCRIMINATOR_SIZE:])
+        return cls(
+            user_id=dec.user_id,
+            farm_state=dec.farm_state,
+            owner=dec.owner,
+            is_farm_delegated=dec.is_farm_delegated,
+            padding0=dec.padding0,
+            rewards_tally_scaled=dec.rewards_tally_scaled,
+            rewards_issued_unclaimed=dec.rewards_issued_unclaimed,
+            last_claim_ts=dec.last_claim_ts,
+            active_stake_scaled=dec.active_stake_scaled,
+            pending_deposit_stake_scaled=dec.pending_deposit_stake_scaled,
+            pending_deposit_stake_ts=dec.pending_deposit_stake_ts,
+            pending_withdrawal_unstake_scaled=dec.pending_withdrawal_unstake_scaled,
+            pending_withdrawal_unstake_ts=dec.pending_withdrawal_unstake_ts,
+            bump=dec.bump,
+            delegatee=dec.delegatee,
+            last_stake_ts=dec.last_stake_ts,
+            padding1=dec.padding1,
+        )
+
+    def to_json(self) -> UserStateJSON:
+        return {
+            "user_id": self.user_id,
+            "farm_state": str(self.farm_state),
+            "owner": str(self.owner),
+            "is_farm_delegated": self.is_farm_delegated,
+            "padding0": self.padding0,
+            "rewards_tally_scaled": self.rewards_tally_scaled,
+            "rewards_issued_unclaimed": self.rewards_issued_unclaimed,
+            "last_claim_ts": self.last_claim_ts,
+            "active_stake_scaled": self.active_stake_scaled,
+            "pending_deposit_stake_scaled": self.pending_deposit_stake_scaled,
+            "pending_deposit_stake_ts": self.pending_deposit_stake_ts,
+            "pending_withdrawal_unstake_scaled": self.pending_withdrawal_unstake_scaled,
+            "pending_withdrawal_unstake_ts": self.pending_withdrawal_unstake_ts,
+            "bump": self.bump,
+            "delegatee": str(self.delegatee),
+            "last_stake_ts": self.last_stake_ts,
+            "padding1": self.padding1,
+        }
+
+    @classmethod
+    def from_json(cls, obj: UserStateJSON) -> "UserState":
+        return cls(
+            user_id=obj["user_id"],
+            farm_state=Pubkey.from_string(obj["farm_state"]),
+            owner=Pubkey.from_string(obj["owner"]),
+            is_farm_delegated=obj["is_farm_delegated"],
+            padding0=obj["padding0"],
+            rewards_tally_scaled=obj["rewards_tally_scaled"],
+            rewards_issued_unclaimed=obj["rewards_issued_unclaimed"],
+            last_claim_ts=obj["last_claim_ts"],
+            active_stake_scaled=obj["active_stake_scaled"],
+            pending_deposit_stake_scaled=obj["pending_deposit_stake_scaled"],
+            pending_deposit_stake_ts=obj["pending_deposit_stake_ts"],
+            pending_withdrawal_unstake_scaled=obj["pending_withdrawal_unstake_scaled"],
+            pending_withdrawal_unstake_ts=obj["pending_withdrawal_unstake_ts"],
+            bump=obj["bump"],
+            delegatee=Pubkey.from_string(obj["delegatee"]),
+            last_stake_ts=obj["last_stake_ts"],
+            padding1=obj["padding1"],
+        )

--- a/codegen_lend/errors/custom.py
+++ b/codegen_lend/errors/custom.py
@@ -617,16 +617,16 @@ class LastTimestampGreaterThanCurrent(ProgramError):
     msg = "The last interval start timestamp is greater than the current timestamp"
 
 
-class LiquidationSlippageError(ProgramError):
+class LiquidationRewardTooSmall(ProgramError):
     def __init__(self) -> None:
         super().__init__(
             6066,
-            "The reward amount is less than the minimum acceptable received collateral",
+            "The reward amount is less than the minimum acceptable received liquidity",
         )
 
     code = 6066
-    name = "LiquidationSlippageError"
-    msg = "The reward amount is less than the minimum acceptable received collateral"
+    name = "LiquidationRewardTooSmall"
+    msg = "The reward amount is less than the minimum acceptable received liquidity"
 
 
 class IsolatedAssetTierViolation(ProgramError):
@@ -792,6 +792,274 @@ class ReserveObsolete(ProgramError):
     msg = "Reserve is marked as obsolete"
 
 
+class ElevationGroupAlreadyActivated(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6083, "Obligation already part of the same elevation group")
+
+    code = 6083
+    name = "ElevationGroupAlreadyActivated"
+    msg = "Obligation already part of the same elevation group"
+
+
+class ObligationInDeprecatedReserve(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6084, "Obligation has a deposit in a deprecated reserve")
+
+    code = 6084
+    name = "ObligationInDeprecatedReserve"
+    msg = "Obligation has a deposit in a deprecated reserve"
+
+
+class ReferrerStateOwnerMismatch(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6085, "Referrer state owner does not match the given signer")
+
+    code = 6085
+    name = "ReferrerStateOwnerMismatch"
+    msg = "Referrer state owner does not match the given signer"
+
+
+class UserMetadataOwnerAlreadySet(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6086, "User metadata owner is already set")
+
+    code = 6086
+    name = "UserMetadataOwnerAlreadySet"
+    msg = "User metadata owner is already set"
+
+
+class CollateralNonLiquidatable(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6087, "This collateral cannot be liquidated (LTV set to 0)")
+
+    code = 6087
+    name = "CollateralNonLiquidatable"
+    msg = "This collateral cannot be liquidated (LTV set to 0)"
+
+
+class BorrowingDisabled(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6088, "Borrowing is disabled")
+
+    code = 6088
+    name = "BorrowingDisabled"
+    msg = "Borrowing is disabled"
+
+
+class BorrowLimitExceeded(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6089, "Cannot borrow above borrow limit")
+
+    code = 6089
+    name = "BorrowLimitExceeded"
+    msg = "Cannot borrow above borrow limit"
+
+
+class DepositLimitExceeded(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6090, "Cannot deposit above deposit limit")
+
+    code = 6090
+    name = "DepositLimitExceeded"
+    msg = "Cannot deposit above deposit limit"
+
+
+class BorrowingDisabledOutsideElevationGroup(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6091, "Reserve does not accept any new borrows outside elevation group"
+        )
+
+    code = 6091
+    name = "BorrowingDisabledOutsideElevationGroup"
+    msg = "Reserve does not accept any new borrows outside elevation group"
+
+
+class NetValueRemainingTooSmall(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6092, "Net value remaining too small")
+
+    code = 6092
+    name = "NetValueRemainingTooSmall"
+    msg = "Net value remaining too small"
+
+
+class WorseLTVBlocked(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6093, "Cannot get the obligation in a worse position")
+
+    code = 6093
+    name = "WorseLTVBlocked"
+    msg = "Cannot get the obligation in a worse position"
+
+
+class LiabilitiesBiggerThanAssets(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6094, "Cannot have more liabilities than assets in a position")
+
+    code = 6094
+    name = "LiabilitiesBiggerThanAssets"
+    msg = "Cannot have more liabilities than assets in a position"
+
+
+class ReserveTokenBalanceMismatch(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6095, "Reserve state and token account cannot drift")
+
+    code = 6095
+    name = "ReserveTokenBalanceMismatch"
+    msg = "Reserve state and token account cannot drift"
+
+
+class ReserveVaultBalanceMismatch(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6096, "Reserve token account has been unexpectedly modified")
+
+    code = 6096
+    name = "ReserveVaultBalanceMismatch"
+    msg = "Reserve token account has been unexpectedly modified"
+
+
+class ReserveAccountingMismatch(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6097, "Reserve internal state accounting has been unexpectedly modified"
+        )
+
+    code = 6097
+    name = "ReserveAccountingMismatch"
+    msg = "Reserve internal state accounting has been unexpectedly modified"
+
+
+class BorrowingAboveUtilizationRateDisabled(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6098, "Borrowing above set utilization rate is disabled")
+
+    code = 6098
+    name = "BorrowingAboveUtilizationRateDisabled"
+    msg = "Borrowing above set utilization rate is disabled"
+
+
+class LiquidationBorrowFactorPriority(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6099, "Liquidation must prioritize the debt with the highest borrow factor"
+        )
+
+    code = 6099
+    name = "LiquidationBorrowFactorPriority"
+    msg = "Liquidation must prioritize the debt with the highest borrow factor"
+
+
+class LiquidationLowestLTVPriority(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6100, "Liquidation must prioritize the collateral with the lowest LTV"
+        )
+
+    code = 6100
+    name = "LiquidationLowestLTVPriority"
+    msg = "Liquidation must prioritize the collateral with the lowest LTV"
+
+
+class ElevationGroupBorrowLimitExceeded(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6101, "Elevation group borrow limit exceeded")
+
+    code = 6101
+    name = "ElevationGroupBorrowLimitExceeded"
+    msg = "Elevation group borrow limit exceeded"
+
+
+class ElevationGroupWithoutDebtReserve(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6102, "The elevation group does not have a debt reserve defined"
+        )
+
+    code = 6102
+    name = "ElevationGroupWithoutDebtReserve"
+    msg = "The elevation group does not have a debt reserve defined"
+
+
+class ElevationGroupMaxCollateralReserveZero(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6103, "The elevation group does not allow any collateral reserves"
+        )
+
+    code = 6103
+    name = "ElevationGroupMaxCollateralReserveZero"
+    msg = "The elevation group does not allow any collateral reserves"
+
+
+class ElevationGroupHasAnotherDebtReserve(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6104,
+            "In elevation group attempt to borrow from a reserve that is not the debt reserve",
+        )
+
+    code = 6104
+    name = "ElevationGroupHasAnotherDebtReserve"
+    msg = "In elevation group attempt to borrow from a reserve that is not the debt reserve"
+
+
+class ElevationGroupDebtReserveAsCollateral(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6105,
+            "The elevation group's debt reserve cannot be used as a collateral reserve",
+        )
+
+    code = 6105
+    name = "ElevationGroupDebtReserveAsCollateral"
+    msg = "The elevation group's debt reserve cannot be used as a collateral reserve"
+
+
+class ObligationCollateralExceedsElevationGroupLimit(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6106,
+            "Obligation have more collateral than the maximum allowed by the elevation group",
+        )
+
+    code = 6106
+    name = "ObligationCollateralExceedsElevationGroupLimit"
+    msg = "Obligation have more collateral than the maximum allowed by the elevation group"
+
+
+class ObligationElevationGroupMultipleDebtReserve(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6107, "Obligation is an elevation group but have more than one debt reserve"
+        )
+
+    code = 6107
+    name = "ObligationElevationGroupMultipleDebtReserve"
+    msg = "Obligation is an elevation group but have more than one debt reserve"
+
+
+class UnsupportedTokenExtension(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(
+            6108, "Mint has a token (2022) extension that is not supported"
+        )
+
+    code = 6108
+    name = "UnsupportedTokenExtension"
+    msg = "Mint has a token (2022) extension that is not supported"
+
+
+class InvalidTokenAccount(ProgramError):
+    def __init__(self) -> None:
+        super().__init__(6109, "Can't have an spl token mint with a t22 account")
+
+    code = 6109
+    name = "InvalidTokenAccount"
+    msg = "Can't have an spl token mint with a t22 account"
+
+
 CustomError = typing.Union[
     InvalidMarketAuthority,
     InvalidMarketOwner,
@@ -859,7 +1127,7 @@ CustomError = typing.Union[
     ObligationEmpty,
     WithdrawalCapReached,
     LastTimestampGreaterThanCurrent,
-    LiquidationSlippageError,
+    LiquidationRewardTooSmall,
     IsolatedAssetTierViolation,
     InconsistentElevationGroup,
     InvalidElevationGroup,
@@ -876,6 +1144,33 @@ CustomError = typing.Union[
     CpiDisabled,
     ShortUrlNotAsciiAlphanumeric,
     ReserveObsolete,
+    ElevationGroupAlreadyActivated,
+    ObligationInDeprecatedReserve,
+    ReferrerStateOwnerMismatch,
+    UserMetadataOwnerAlreadySet,
+    CollateralNonLiquidatable,
+    BorrowingDisabled,
+    BorrowLimitExceeded,
+    DepositLimitExceeded,
+    BorrowingDisabledOutsideElevationGroup,
+    NetValueRemainingTooSmall,
+    WorseLTVBlocked,
+    LiabilitiesBiggerThanAssets,
+    ReserveTokenBalanceMismatch,
+    ReserveVaultBalanceMismatch,
+    ReserveAccountingMismatch,
+    BorrowingAboveUtilizationRateDisabled,
+    LiquidationBorrowFactorPriority,
+    LiquidationLowestLTVPriority,
+    ElevationGroupBorrowLimitExceeded,
+    ElevationGroupWithoutDebtReserve,
+    ElevationGroupMaxCollateralReserveZero,
+    ElevationGroupHasAnotherDebtReserve,
+    ElevationGroupDebtReserveAsCollateral,
+    ObligationCollateralExceedsElevationGroupLimit,
+    ObligationElevationGroupMultipleDebtReserve,
+    UnsupportedTokenExtension,
+    InvalidTokenAccount,
 ]
 CUSTOM_ERROR_MAP: dict[int, CustomError] = {
     6000: InvalidMarketAuthority(),
@@ -944,7 +1239,7 @@ CUSTOM_ERROR_MAP: dict[int, CustomError] = {
     6063: ObligationEmpty(),
     6064: WithdrawalCapReached(),
     6065: LastTimestampGreaterThanCurrent(),
-    6066: LiquidationSlippageError(),
+    6066: LiquidationRewardTooSmall(),
     6067: IsolatedAssetTierViolation(),
     6068: InconsistentElevationGroup(),
     6069: InvalidElevationGroup(),
@@ -961,6 +1256,33 @@ CUSTOM_ERROR_MAP: dict[int, CustomError] = {
     6080: CpiDisabled(),
     6081: ShortUrlNotAsciiAlphanumeric(),
     6082: ReserveObsolete(),
+    6083: ElevationGroupAlreadyActivated(),
+    6084: ObligationInDeprecatedReserve(),
+    6085: ReferrerStateOwnerMismatch(),
+    6086: UserMetadataOwnerAlreadySet(),
+    6087: CollateralNonLiquidatable(),
+    6088: BorrowingDisabled(),
+    6089: BorrowLimitExceeded(),
+    6090: DepositLimitExceeded(),
+    6091: BorrowingDisabledOutsideElevationGroup(),
+    6092: NetValueRemainingTooSmall(),
+    6093: WorseLTVBlocked(),
+    6094: LiabilitiesBiggerThanAssets(),
+    6095: ReserveTokenBalanceMismatch(),
+    6096: ReserveVaultBalanceMismatch(),
+    6097: ReserveAccountingMismatch(),
+    6098: BorrowingAboveUtilizationRateDisabled(),
+    6099: LiquidationBorrowFactorPriority(),
+    6100: LiquidationLowestLTVPriority(),
+    6101: ElevationGroupBorrowLimitExceeded(),
+    6102: ElevationGroupWithoutDebtReserve(),
+    6103: ElevationGroupMaxCollateralReserveZero(),
+    6104: ElevationGroupHasAnotherDebtReserve(),
+    6105: ElevationGroupDebtReserveAsCollateral(),
+    6106: ObligationCollateralExceedsElevationGroupLimit(),
+    6107: ObligationElevationGroupMultipleDebtReserve(),
+    6108: UnsupportedTokenExtension(),
+    6109: InvalidTokenAccount(),
 }
 
 

--- a/codegen_lend/instructions/__init__.py
+++ b/codegen_lend/instructions/__init__.py
@@ -23,6 +23,13 @@ from .update_reserve_config import (
     UpdateReserveConfigArgs,
     UpdateReserveConfigAccounts,
 )
+from .redeem_fees import redeem_fees, RedeemFeesAccounts
+from .socialize_loss import socialize_loss, SocializeLossArgs, SocializeLossAccounts
+from .withdraw_protocol_fee import (
+    withdraw_protocol_fee,
+    WithdrawProtocolFeeArgs,
+    WithdrawProtocolFeeAccounts,
+)
 from .refresh_reserve import refresh_reserve, RefreshReserveAccounts
 from .deposit_reserve_liquidity import (
     deposit_reserve_liquidity,
@@ -81,7 +88,6 @@ from .liquidate_obligation_and_redeem_reserve_collateral import (
     LiquidateObligationAndRedeemReserveCollateralArgs,
     LiquidateObligationAndRedeemReserveCollateralAccounts,
 )
-from .redeem_fees import redeem_fees, RedeemFeesAccounts
 from .flash_repay_reserve_liquidity import (
     flash_repay_reserve_liquidity,
     FlashRepayReserveLiquidityArgs,
@@ -92,7 +98,6 @@ from .flash_borrow_reserve_liquidity import (
     FlashBorrowReserveLiquidityArgs,
     FlashBorrowReserveLiquidityAccounts,
 )
-from .socialize_loss import socialize_loss, SocializeLossArgs, SocializeLossAccounts
 from .request_elevation_group import (
     request_elevation_group,
     RequestElevationGroupArgs,
@@ -109,11 +114,6 @@ from .init_user_metadata import (
     InitUserMetadataAccounts,
 )
 from .withdraw_referrer_fees import withdraw_referrer_fees, WithdrawReferrerFeesAccounts
-from .withdraw_protocol_fee import (
-    withdraw_protocol_fee,
-    WithdrawProtocolFeeArgs,
-    WithdrawProtocolFeeAccounts,
-)
 from .init_referrer_state_and_short_url import (
     init_referrer_state_and_short_url,
     InitReferrerStateAndShortUrlArgs,
@@ -122,4 +122,9 @@ from .init_referrer_state_and_short_url import (
 from .delete_referrer_state_and_short_url import (
     delete_referrer_state_and_short_url,
     DeleteReferrerStateAndShortUrlAccounts,
+)
+from .idl_missing_types import (
+    idl_missing_types,
+    IdlMissingTypesArgs,
+    IdlMissingTypesAccounts,
 )

--- a/codegen_lend/instructions/borrow_obligation_liquidity.py
+++ b/codegen_lend/instructions/borrow_obligation_liquidity.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class BorrowObligationLiquidityArgs(typing.TypedDict):
@@ -20,10 +20,11 @@ class BorrowObligationLiquidityAccounts(typing.TypedDict):
     lending_market: Pubkey
     lending_market_authority: Pubkey
     borrow_reserve: Pubkey
+    borrow_reserve_liquidity_mint: Pubkey
     reserve_source_liquidity: Pubkey
     borrow_reserve_liquidity_fee_receiver: Pubkey
     user_destination_liquidity: Pubkey
-    referrer_token_state: Pubkey
+    referrer_token_state: typing.Optional[Pubkey]
     instruction_sysvar_account: Pubkey
 
 
@@ -48,6 +49,11 @@ def borrow_obligation_liquidity(
             pubkey=accounts["borrow_reserve"], is_signer=False, is_writable=True
         ),
         AccountMeta(
+            pubkey=accounts["borrow_reserve_liquidity_mint"],
+            is_signer=False,
+            is_writable=True,
+        ),
+        AccountMeta(
             pubkey=accounts["reserve_source_liquidity"],
             is_signer=False,
             is_writable=True,
@@ -62,8 +68,14 @@ def borrow_obligation_liquidity(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(
-            pubkey=accounts["referrer_token_state"], is_signer=False, is_writable=True
+        (
+            AccountMeta(
+                pubkey=accounts["referrer_token_state"],
+                is_signer=False,
+                is_writable=True,
+            )
+            if accounts["referrer_token_state"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(

--- a/codegen_lend/instructions/delete_referrer_state_and_short_url.py
+++ b/codegen_lend/instructions/delete_referrer_state_and_short_url.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class DeleteReferrerStateAndShortUrlAccounts(typing.TypedDict):

--- a/codegen_lend/instructions/deposit_obligation_collateral.py
+++ b/codegen_lend/instructions/deposit_obligation_collateral.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class DepositObligationCollateralArgs(typing.TypedDict):

--- a/codegen_lend/instructions/deposit_reserve_liquidity.py
+++ b/codegen_lend/instructions/deposit_reserve_liquidity.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class DepositReserveLiquidityArgs(typing.TypedDict):
@@ -19,10 +18,14 @@ class DepositReserveLiquidityAccounts(typing.TypedDict):
     reserve: Pubkey
     lending_market: Pubkey
     lending_market_authority: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_liquidity_supply: Pubkey
     reserve_collateral_mint: Pubkey
     user_source_liquidity: Pubkey
     user_destination_collateral: Pubkey
+    collateral_token_program: Pubkey
+    liquidity_token_program: Pubkey
+    instruction_sysvar_account: Pubkey
 
 
 def deposit_reserve_liquidity(
@@ -43,6 +46,9 @@ def deposit_reserve_liquidity(
             is_writable=False,
         ),
         AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
             pubkey=accounts["reserve_liquidity_supply"],
             is_signer=False,
             is_writable=True,
@@ -60,7 +66,21 @@ def deposit_reserve_liquidity(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["collateral_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["liquidity_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["instruction_sysvar_account"],
+            is_signer=False,
+            is_writable=False,
+        ),
     ]
     if remaining_accounts is not None:
         keys += remaining_accounts

--- a/codegen_lend/instructions/deposit_reserve_liquidity_and_obligation_collateral.py
+++ b/codegen_lend/instructions/deposit_reserve_liquidity_and_obligation_collateral.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class DepositReserveLiquidityAndObligationCollateralArgs(typing.TypedDict):
@@ -20,11 +19,14 @@ class DepositReserveLiquidityAndObligationCollateralAccounts(typing.TypedDict):
     lending_market: Pubkey
     lending_market_authority: Pubkey
     reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_liquidity_supply: Pubkey
     reserve_collateral_mint: Pubkey
     reserve_destination_deposit_collateral: Pubkey
     user_source_liquidity: Pubkey
-    user_destination_collateral: Pubkey
+    placeholder_user_destination_collateral: typing.Optional[Pubkey]
+    collateral_token_program: Pubkey
+    liquidity_token_program: Pubkey
     instruction_sysvar_account: Pubkey
 
 
@@ -47,6 +49,9 @@ def deposit_reserve_liquidity_and_obligation_collateral(
         ),
         AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=True),
         AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
             pubkey=accounts["reserve_liquidity_supply"],
             is_signer=False,
             is_writable=True,
@@ -64,12 +69,25 @@ def deposit_reserve_liquidity_and_obligation_collateral(
         AccountMeta(
             pubkey=accounts["user_source_liquidity"], is_signer=False, is_writable=True
         ),
-        AccountMeta(
-            pubkey=accounts["user_destination_collateral"],
-            is_signer=False,
-            is_writable=True,
+        (
+            AccountMeta(
+                pubkey=accounts["placeholder_user_destination_collateral"],
+                is_signer=False,
+                is_writable=False,
+            )
+            if accounts["placeholder_user_destination_collateral"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["collateral_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["liquidity_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
         AccountMeta(
             pubkey=accounts["instruction_sysvar_account"],
             is_signer=False,

--- a/codegen_lend/instructions/flash_borrow_reserve_liquidity.py
+++ b/codegen_lend/instructions/flash_borrow_reserve_liquidity.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class FlashBorrowReserveLiquidityArgs(typing.TypedDict):
@@ -19,11 +19,12 @@ class FlashBorrowReserveLiquidityAccounts(typing.TypedDict):
     lending_market_authority: Pubkey
     lending_market: Pubkey
     reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_source_liquidity: Pubkey
     user_destination_liquidity: Pubkey
     reserve_liquidity_fee_receiver: Pubkey
-    referrer_token_state: Pubkey
-    referrer_account: Pubkey
+    referrer_token_state: typing.Optional[Pubkey]
+    referrer_account: typing.Optional[Pubkey]
     sysvar_info: Pubkey
 
 
@@ -49,6 +50,9 @@ def flash_borrow_reserve_liquidity(
         ),
         AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=True),
         AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
             pubkey=accounts["reserve_source_liquidity"],
             is_signer=False,
             is_writable=True,
@@ -63,11 +67,21 @@ def flash_borrow_reserve_liquidity(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(
-            pubkey=accounts["referrer_token_state"], is_signer=False, is_writable=True
+        (
+            AccountMeta(
+                pubkey=accounts["referrer_token_state"],
+                is_signer=False,
+                is_writable=True,
+            )
+            if accounts["referrer_token_state"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
-        AccountMeta(
-            pubkey=accounts["referrer_account"], is_signer=False, is_writable=True
+        (
+            AccountMeta(
+                pubkey=accounts["referrer_account"], is_signer=False, is_writable=True
+            )
+            if accounts["referrer_account"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
         AccountMeta(pubkey=accounts["sysvar_info"], is_signer=False, is_writable=False),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),

--- a/codegen_lend/instructions/flash_repay_reserve_liquidity.py
+++ b/codegen_lend/instructions/flash_repay_reserve_liquidity.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class FlashRepayReserveLiquidityArgs(typing.TypedDict):
@@ -22,11 +22,12 @@ class FlashRepayReserveLiquidityAccounts(typing.TypedDict):
     lending_market_authority: Pubkey
     lending_market: Pubkey
     reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_destination_liquidity: Pubkey
     user_source_liquidity: Pubkey
     reserve_liquidity_fee_receiver: Pubkey
-    referrer_token_state: Pubkey
-    referrer_account: Pubkey
+    referrer_token_state: typing.Optional[Pubkey]
+    referrer_account: typing.Optional[Pubkey]
     sysvar_info: Pubkey
 
 
@@ -52,6 +53,9 @@ def flash_repay_reserve_liquidity(
         ),
         AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=True),
         AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
             pubkey=accounts["reserve_destination_liquidity"],
             is_signer=False,
             is_writable=True,
@@ -64,11 +68,21 @@ def flash_repay_reserve_liquidity(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(
-            pubkey=accounts["referrer_token_state"], is_signer=False, is_writable=True
+        (
+            AccountMeta(
+                pubkey=accounts["referrer_token_state"],
+                is_signer=False,
+                is_writable=True,
+            )
+            if accounts["referrer_token_state"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
-        AccountMeta(
-            pubkey=accounts["referrer_account"], is_signer=False, is_writable=True
+        (
+            AccountMeta(
+                pubkey=accounts["referrer_account"], is_signer=False, is_writable=True
+            )
+            if accounts["referrer_account"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
         AccountMeta(pubkey=accounts["sysvar_info"], is_signer=False, is_writable=False),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),

--- a/codegen_lend/instructions/idl_missing_types.py
+++ b/codegen_lend/instructions/idl_missing_types.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import typing
+from solders.pubkey import Pubkey
+from solders.instruction import Instruction, AccountMeta
+import borsh_construct as borsh
+from .. import types
+from ..program_id import PROGRAM_ID
+
+
+class IdlMissingTypesArgs(typing.TypedDict):
+    reserve_farm_kind: types.reserve_farm_kind.ReserveFarmKindKind
+    asset_tier: types.asset_tier.AssetTierKind
+    fee_calculation: types.fee_calculation.FeeCalculationKind
+    reserve_status: types.reserve_status.ReserveStatusKind
+    update_config_mode: types.update_config_mode.UpdateConfigModeKind
+    update_lending_market_config_value: (
+        types.update_lending_market_config_value.UpdateLendingMarketConfigValueKind
+    )
+    update_lending_market_config_mode: (
+        types.update_lending_market_mode.UpdateLendingMarketModeKind
+    )
+
+
+layout = borsh.CStruct(
+    "reserve_farm_kind" / types.reserve_farm_kind.layout,
+    "asset_tier" / types.asset_tier.layout,
+    "fee_calculation" / types.fee_calculation.layout,
+    "reserve_status" / types.reserve_status.layout,
+    "update_config_mode" / types.update_config_mode.layout,
+    "update_lending_market_config_value"
+    / types.update_lending_market_config_value.layout,
+    "update_lending_market_config_mode" / types.update_lending_market_mode.layout,
+)
+
+
+class IdlMissingTypesAccounts(typing.TypedDict):
+    lending_market_owner: Pubkey
+    lending_market: Pubkey
+    reserve: Pubkey
+
+
+def idl_missing_types(
+    args: IdlMissingTypesArgs,
+    accounts: IdlMissingTypesAccounts,
+    program_id: Pubkey = PROGRAM_ID,
+    remaining_accounts: typing.Optional[typing.List[AccountMeta]] = None,
+) -> Instruction:
+    keys: list[AccountMeta] = [
+        AccountMeta(
+            pubkey=accounts["lending_market_owner"], is_signer=True, is_writable=False
+        ),
+        AccountMeta(
+            pubkey=accounts["lending_market"], is_signer=False, is_writable=False
+        ),
+        AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=True),
+    ]
+    if remaining_accounts is not None:
+        keys += remaining_accounts
+    identifier = b"\x82P&\x99P\xd4\xb6\xfd"
+    encoded_args = layout.build(
+        {
+            "reserve_farm_kind": args["reserve_farm_kind"].to_encodable(),
+            "asset_tier": args["asset_tier"].to_encodable(),
+            "fee_calculation": args["fee_calculation"].to_encodable(),
+            "reserve_status": args["reserve_status"].to_encodable(),
+            "update_config_mode": args["update_config_mode"].to_encodable(),
+            "update_lending_market_config_value": args[
+                "update_lending_market_config_value"
+            ].to_encodable(),
+            "update_lending_market_config_mode": args[
+                "update_lending_market_config_mode"
+            ].to_encodable(),
+        }
+    )
+    data = identifier + encoded_args
+    return Instruction(program_id, data, keys)

--- a/codegen_lend/instructions/init_farms_for_reserve.py
+++ b/codegen_lend/instructions/init_farms_for_reserve.py
@@ -3,10 +3,9 @@ import typing
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitFarmsForReserveArgs(typing.TypedDict):
@@ -57,7 +56,6 @@ def init_farms_for_reserve(
             pubkey=accounts["farms_vault_authority"], is_signer=False, is_writable=False
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
     ]
     if remaining_accounts is not None:

--- a/codegen_lend/instructions/init_lending_market.py
+++ b/codegen_lend/instructions/init_lending_market.py
@@ -5,7 +5,7 @@ from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitLendingMarketArgs(typing.TypedDict):

--- a/codegen_lend/instructions/init_obligation.py
+++ b/codegen_lend/instructions/init_obligation.py
@@ -3,11 +3,10 @@ import typing
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-import codegen_lend.lend_types as types
-from codegen_lend.program_id import PROGRAM_ID
+from .. import types
+from ..program_id import PROGRAM_ID
 
 
 class InitObligationArgs(typing.TypedDict):
@@ -19,6 +18,7 @@ layout = borsh.CStruct("args" / types.init_obligation_args.InitObligationArgs.la
 
 class InitObligationAccounts(typing.TypedDict):
     obligation_owner: Pubkey
+    fee_payer: Pubkey
     obligation: Pubkey
     lending_market: Pubkey
     seed1_account: Pubkey
@@ -34,8 +34,9 @@ def init_obligation(
 ) -> Instruction:
     keys: list[AccountMeta] = [
         AccountMeta(
-            pubkey=accounts["obligation_owner"], is_signer=True, is_writable=True
+            pubkey=accounts["obligation_owner"], is_signer=True, is_writable=False
         ),
+        AccountMeta(pubkey=accounts["fee_payer"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["obligation"], is_signer=False, is_writable=True),
         AccountMeta(
             pubkey=accounts["lending_market"], is_signer=False, is_writable=False
@@ -50,7 +51,6 @@ def init_obligation(
             pubkey=accounts["owner_user_metadata"], is_signer=False, is_writable=False
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
     ]
     if remaining_accounts is not None:

--- a/codegen_lend/instructions/init_obligation_farms_for_reserve.py
+++ b/codegen_lend/instructions/init_obligation_farms_for_reserve.py
@@ -3,10 +3,9 @@ import typing
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitObligationFarmsForReserveArgs(typing.TypedDict):
@@ -57,7 +56,6 @@ def init_obligation_farms_for_reserve(
             pubkey=accounts["farms_program"], is_signer=False, is_writable=False
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
     ]
     if remaining_accounts is not None:

--- a/codegen_lend/instructions/init_referrer_state_and_short_url.py
+++ b/codegen_lend/instructions/init_referrer_state_and_short_url.py
@@ -5,7 +5,7 @@ from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitReferrerStateAndShortUrlArgs(typing.TypedDict):
@@ -19,6 +19,7 @@ class InitReferrerStateAndShortUrlAccounts(typing.TypedDict):
     referrer: Pubkey
     referrer_state: Pubkey
     referrer_short_url: Pubkey
+    referrer_user_metadata: Pubkey
 
 
 def init_referrer_state_and_short_url(
@@ -34,6 +35,11 @@ def init_referrer_state_and_short_url(
         ),
         AccountMeta(
             pubkey=accounts["referrer_short_url"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["referrer_user_metadata"],
+            is_signer=False,
+            is_writable=False,
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),

--- a/codegen_lend/instructions/init_referrer_token_state.py
+++ b/codegen_lend/instructions/init_referrer_token_state.py
@@ -6,7 +6,7 @@ from solders.sysvar import RENT
 from solders.instruction import Instruction, AccountMeta
 from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitReferrerTokenStateArgs(typing.TypedDict):

--- a/codegen_lend/instructions/init_reserve.py
+++ b/codegen_lend/instructions/init_reserve.py
@@ -3,9 +3,8 @@ import typing
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitReserveAccounts(typing.TypedDict):
@@ -18,6 +17,8 @@ class InitReserveAccounts(typing.TypedDict):
     fee_receiver: Pubkey
     reserve_collateral_mint: Pubkey
     reserve_collateral_supply: Pubkey
+    liquidity_token_program: Pubkey
+    collateral_token_program: Pubkey
 
 
 def init_reserve(
@@ -60,7 +61,16 @@ def init_reserve(
             is_writable=True,
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["liquidity_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["collateral_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
     ]
     if remaining_accounts is not None:

--- a/codegen_lend/instructions/init_user_metadata.py
+++ b/codegen_lend/instructions/init_user_metadata.py
@@ -6,20 +6,21 @@ from solders.sysvar import RENT
 from solders.instruction import Instruction, AccountMeta
 from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class InitUserMetadataArgs(typing.TypedDict):
-    referrer: Pubkey
     user_lookup_table: Pubkey
 
 
-layout = borsh.CStruct("referrer" / BorshPubkey, "user_lookup_table" / BorshPubkey)
+layout = borsh.CStruct("user_lookup_table" / BorshPubkey)
 
 
 class InitUserMetadataAccounts(typing.TypedDict):
     owner: Pubkey
+    fee_payer: Pubkey
     user_metadata: Pubkey
+    referrer_user_metadata: typing.Optional[Pubkey]
 
 
 def init_user_metadata(
@@ -29,9 +30,19 @@ def init_user_metadata(
     remaining_accounts: typing.Optional[typing.List[AccountMeta]] = None,
 ) -> Instruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["owner"], is_signer=True, is_writable=True),
+        AccountMeta(pubkey=accounts["owner"], is_signer=True, is_writable=False),
+        AccountMeta(pubkey=accounts["fee_payer"], is_signer=True, is_writable=True),
         AccountMeta(
             pubkey=accounts["user_metadata"], is_signer=False, is_writable=True
+        ),
+        (
+            AccountMeta(
+                pubkey=accounts["referrer_user_metadata"],
+                is_signer=False,
+                is_writable=False,
+            )
+            if accounts["referrer_user_metadata"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
@@ -41,7 +52,6 @@ def init_user_metadata(
     identifier = b"u\xa9\xb0E\xc5\x17\x0f\xa2"
     encoded_args = layout.build(
         {
-            "referrer": args["referrer"],
             "user_lookup_table": args["user_lookup_table"],
         }
     )

--- a/codegen_lend/instructions/redeem_fees.py
+++ b/codegen_lend/instructions/redeem_fees.py
@@ -3,11 +3,12 @@ import typing
 from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RedeemFeesAccounts(typing.TypedDict):
     reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_liquidity_fee_receiver: Pubkey
     reserve_supply_liquidity: Pubkey
     lending_market: Pubkey
@@ -21,6 +22,9 @@ def redeem_fees(
 ) -> Instruction:
     keys: list[AccountMeta] = [
         AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["reserve_liquidity_fee_receiver"],
             is_signer=False,

--- a/codegen_lend/instructions/redeem_reserve_collateral.py
+++ b/codegen_lend/instructions/redeem_reserve_collateral.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RedeemReserveCollateralArgs(typing.TypedDict):
@@ -19,10 +18,14 @@ class RedeemReserveCollateralAccounts(typing.TypedDict):
     lending_market: Pubkey
     reserve: Pubkey
     lending_market_authority: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_collateral_mint: Pubkey
     reserve_liquidity_supply: Pubkey
     user_source_collateral: Pubkey
     user_destination_liquidity: Pubkey
+    collateral_token_program: Pubkey
+    liquidity_token_program: Pubkey
+    instruction_sysvar_account: Pubkey
 
 
 def redeem_reserve_collateral(
@@ -43,6 +46,9 @@ def redeem_reserve_collateral(
             is_writable=False,
         ),
         AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
             pubkey=accounts["reserve_collateral_mint"],
             is_signer=False,
             is_writable=True,
@@ -60,7 +66,21 @@ def redeem_reserve_collateral(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["collateral_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["liquidity_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["instruction_sysvar_account"],
+            is_signer=False,
+            is_writable=False,
+        ),
     ]
     if remaining_accounts is not None:
         keys += remaining_accounts

--- a/codegen_lend/instructions/refresh_obligation.py
+++ b/codegen_lend/instructions/refresh_obligation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RefreshObligationAccounts(typing.TypedDict):

--- a/codegen_lend/instructions/refresh_obligation_farms_for_reserve.py
+++ b/codegen_lend/instructions/refresh_obligation_farms_for_reserve.py
@@ -3,10 +3,9 @@ import typing
 from solders.pubkey import Pubkey
 from solders.system_program import ID as SYS_PROGRAM_ID
 from solders.sysvar import RENT
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RefreshObligationFarmsForReserveArgs(typing.TypedDict):
@@ -57,7 +56,6 @@ def refresh_obligation_farms_for_reserve(
             pubkey=accounts["farms_program"], is_signer=False, is_writable=False
         ),
         AccountMeta(pubkey=RENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYS_PROGRAM_ID, is_signer=False, is_writable=False),
     ]
     if remaining_accounts is not None:

--- a/codegen_lend/instructions/refresh_reserve.py
+++ b/codegen_lend/instructions/refresh_reserve.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RefreshReserveAccounts(typing.TypedDict):
     reserve: Pubkey
     lending_market: Pubkey
-    pyth_oracle: Pubkey
-    switchboard_price_oracle: Pubkey
-    switchboard_twap_oracle: Pubkey
-    scope_prices: Pubkey
+    pyth_oracle: typing.Optional[Pubkey]
+    switchboard_price_oracle: typing.Optional[Pubkey]
+    switchboard_twap_oracle: typing.Optional[Pubkey]
+    scope_prices: typing.Optional[Pubkey]
 
 
 def refresh_reserve(
@@ -24,19 +24,37 @@ def refresh_reserve(
         AccountMeta(
             pubkey=accounts["lending_market"], is_signer=False, is_writable=False
         ),
-        AccountMeta(pubkey=accounts["pyth_oracle"], is_signer=False, is_writable=False),
-        AccountMeta(
-            pubkey=accounts["switchboard_price_oracle"],
-            is_signer=False,
-            is_writable=False,
+        (
+            AccountMeta(
+                pubkey=accounts["pyth_oracle"], is_signer=False, is_writable=False
+            )
+            if accounts["pyth_oracle"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
-        AccountMeta(
-            pubkey=accounts["switchboard_twap_oracle"],
-            is_signer=False,
-            is_writable=False,
+        (
+            AccountMeta(
+                pubkey=accounts["switchboard_price_oracle"],
+                is_signer=False,
+                is_writable=False,
+            )
+            if accounts["switchboard_price_oracle"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
-        AccountMeta(
-            pubkey=accounts["scope_prices"], is_signer=False, is_writable=False
+        (
+            AccountMeta(
+                pubkey=accounts["switchboard_twap_oracle"],
+                is_signer=False,
+                is_writable=False,
+            )
+            if accounts["switchboard_twap_oracle"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
+        ),
+        (
+            AccountMeta(
+                pubkey=accounts["scope_prices"], is_signer=False, is_writable=False
+            )
+            if accounts["scope_prices"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
     ]
     if remaining_accounts is not None:

--- a/codegen_lend/instructions/repay_obligation_liquidity.py
+++ b/codegen_lend/instructions/repay_obligation_liquidity.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RepayObligationLiquidityArgs(typing.TypedDict):
@@ -19,6 +19,7 @@ class RepayObligationLiquidityAccounts(typing.TypedDict):
     obligation: Pubkey
     lending_market: Pubkey
     repay_reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_destination_liquidity: Pubkey
     user_source_liquidity: Pubkey
     instruction_sysvar_account: Pubkey
@@ -38,6 +39,9 @@ def repay_obligation_liquidity(
         ),
         AccountMeta(
             pubkey=accounts["repay_reserve"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
         ),
         AccountMeta(
             pubkey=accounts["reserve_destination_liquidity"],

--- a/codegen_lend/instructions/request_elevation_group.py
+++ b/codegen_lend/instructions/request_elevation_group.py
@@ -3,7 +3,7 @@ import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class RequestElevationGroupArgs(typing.TypedDict):

--- a/codegen_lend/instructions/socialize_loss.py
+++ b/codegen_lend/instructions/socialize_loss.py
@@ -3,7 +3,7 @@ import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class SocializeLossArgs(typing.TypedDict):

--- a/codegen_lend/instructions/update_lending_market.py
+++ b/codegen_lend/instructions/update_lending_market.py
@@ -3,7 +3,7 @@ import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class UpdateLendingMarketArgs(typing.TypedDict):

--- a/codegen_lend/instructions/update_lending_market_owner.py
+++ b/codegen_lend/instructions/update_lending_market_owner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class UpdateLendingMarketOwnerAccounts(typing.TypedDict):

--- a/codegen_lend/instructions/update_reserve_config.py
+++ b/codegen_lend/instructions/update_reserve_config.py
@@ -3,15 +3,18 @@ import typing
 from solders.pubkey import Pubkey
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class UpdateReserveConfigArgs(typing.TypedDict):
     mode: int
-    value: list[int]
+    value: bytes
+    skip_validation: bool
 
 
-layout = borsh.CStruct("mode" / borsh.U64, "value" / borsh.U8[648])
+layout = borsh.CStruct(
+    "mode" / borsh.U64, "value" / borsh.Bytes, "skip_validation" / borsh.Bool
+)
 
 
 class UpdateReserveConfigAccounts(typing.TypedDict):
@@ -42,6 +45,7 @@ def update_reserve_config(
         {
             "mode": args["mode"],
             "value": args["value"],
+            "skip_validation": args["skip_validation"],
         }
     )
     data = identifier + encoded_args

--- a/codegen_lend/instructions/withdraw_obligation_collateral.py
+++ b/codegen_lend/instructions/withdraw_obligation_collateral.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class WithdrawObligationCollateralArgs(typing.TypedDict):
@@ -43,7 +43,7 @@ def withdraw_obligation_collateral(
             is_writable=False,
         ),
         AccountMeta(
-            pubkey=accounts["withdraw_reserve"], is_signer=False, is_writable=False
+            pubkey=accounts["withdraw_reserve"], is_signer=False, is_writable=True
         ),
         AccountMeta(
             pubkey=accounts["reserve_source_collateral"],

--- a/codegen_lend/instructions/withdraw_obligation_collateral_and_redeem_reserve_collateral.py
+++ b/codegen_lend/instructions/withdraw_obligation_collateral_and_redeem_reserve_collateral.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 import typing
 from solders.pubkey import Pubkey
-from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class WithdrawObligationCollateralAndRedeemReserveCollateralArgs(typing.TypedDict):
@@ -20,11 +19,14 @@ class WithdrawObligationCollateralAndRedeemReserveCollateralAccounts(typing.Type
     lending_market: Pubkey
     lending_market_authority: Pubkey
     withdraw_reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_source_collateral: Pubkey
     reserve_collateral_mint: Pubkey
     reserve_liquidity_supply: Pubkey
     user_destination_liquidity: Pubkey
-    user_destination_collateral: Pubkey
+    placeholder_user_destination_collateral: typing.Optional[Pubkey]
+    collateral_token_program: Pubkey
+    liquidity_token_program: Pubkey
     instruction_sysvar_account: Pubkey
 
 
@@ -35,7 +37,7 @@ def withdraw_obligation_collateral_and_redeem_reserve_collateral(
     remaining_accounts: typing.Optional[typing.List[AccountMeta]] = None,
 ) -> Instruction:
     keys: list[AccountMeta] = [
-        AccountMeta(pubkey=accounts["owner"], is_signer=True, is_writable=False),
+        AccountMeta(pubkey=accounts["owner"], is_signer=True, is_writable=True),
         AccountMeta(pubkey=accounts["obligation"], is_signer=False, is_writable=True),
         AccountMeta(
             pubkey=accounts["lending_market"], is_signer=False, is_writable=False
@@ -47,6 +49,9 @@ def withdraw_obligation_collateral_and_redeem_reserve_collateral(
         ),
         AccountMeta(
             pubkey=accounts["withdraw_reserve"], is_signer=False, is_writable=True
+        ),
+        AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
         ),
         AccountMeta(
             pubkey=accounts["reserve_source_collateral"],
@@ -68,12 +73,25 @@ def withdraw_obligation_collateral_and_redeem_reserve_collateral(
             is_signer=False,
             is_writable=True,
         ),
-        AccountMeta(
-            pubkey=accounts["user_destination_collateral"],
-            is_signer=False,
-            is_writable=True,
+        (
+            AccountMeta(
+                pubkey=accounts["placeholder_user_destination_collateral"],
+                is_signer=False,
+                is_writable=False,
+            )
+            if accounts["placeholder_user_destination_collateral"]
+            else AccountMeta(pubkey=program_id, is_signer=False, is_writable=False)
         ),
-        AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["collateral_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
+        AccountMeta(
+            pubkey=accounts["liquidity_token_program"],
+            is_signer=False,
+            is_writable=False,
+        ),
         AccountMeta(
             pubkey=accounts["instruction_sysvar_account"],
             is_signer=False,

--- a/codegen_lend/instructions/withdraw_protocol_fee.py
+++ b/codegen_lend/instructions/withdraw_protocol_fee.py
@@ -4,7 +4,7 @@ from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
 import borsh_construct as borsh
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class WithdrawProtocolFeeArgs(typing.TypedDict):
@@ -18,6 +18,7 @@ class WithdrawProtocolFeeAccounts(typing.TypedDict):
     lending_market_owner: Pubkey
     lending_market: Pubkey
     reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     lending_market_authority: Pubkey
     fee_vault: Pubkey
     lending_market_owner_ata: Pubkey
@@ -37,6 +38,9 @@ def withdraw_protocol_fee(
             pubkey=accounts["lending_market"], is_signer=False, is_writable=False
         ),
         AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=False),
+        AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["lending_market_authority"],
             is_signer=False,

--- a/codegen_lend/instructions/withdraw_referrer_fees.py
+++ b/codegen_lend/instructions/withdraw_referrer_fees.py
@@ -3,13 +3,14 @@ import typing
 from solders.pubkey import Pubkey
 from spl.token.constants import TOKEN_PROGRAM_ID
 from solders.instruction import Instruction, AccountMeta
-from codegen_lend.program_id import PROGRAM_ID
+from ..program_id import PROGRAM_ID
 
 
 class WithdrawReferrerFeesAccounts(typing.TypedDict):
     referrer: Pubkey
     referrer_token_state: Pubkey
     reserve: Pubkey
+    reserve_liquidity_mint: Pubkey
     reserve_supply_liquidity: Pubkey
     referrer_token_account: Pubkey
     lending_market: Pubkey
@@ -27,6 +28,9 @@ def withdraw_referrer_fees(
             pubkey=accounts["referrer_token_state"], is_signer=False, is_writable=True
         ),
         AccountMeta(pubkey=accounts["reserve"], is_signer=False, is_writable=True),
+        AccountMeta(
+            pubkey=accounts["reserve_liquidity_mint"], is_signer=False, is_writable=True
+        ),
         AccountMeta(
             pubkey=accounts["reserve_supply_liquidity"],
             is_signer=False,

--- a/codegen_lend/lend_types/asset_tier.py
+++ b/codegen_lend/lend_types/asset_tier.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class RegularJSON(typing.TypedDict):
     kind: typing.Literal["Regular"]

--- a/codegen_lend/lend_types/big_fraction_bytes.py
+++ b/codegen_lend/lend_types/big_fraction_bytes.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Adapted to release 1.6.2
+# No change
+
 
 class BigFractionBytesJSON(typing.TypedDict):
     value: list[int]

--- a/codegen_lend/lend_types/borrow_rate_curve.py
+++ b/codegen_lend/lend_types/borrow_rate_curve.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Release 1.6.2: no change
+
 
 class BorrowRateCurveJSON(typing.TypedDict):
     points: list[curve_point.CurvePointJSON]

--- a/codegen_lend/lend_types/curve_point.py
+++ b/codegen_lend/lend_types/curve_point.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class CurvePointJSON(typing.TypedDict):
     utilization_rate_bps: int

--- a/codegen_lend/lend_types/elevation_group.py
+++ b/codegen_lend/lend_types/elevation_group.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 import typing
 from dataclasses import dataclass
 from construct import Container
+from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
+
+
+# Adapting to release 1.6.2
+
+"""
+max_reserves_as_collateral: u8,
+padding_0: u8
+debt_reserve: Pubkey
+padding_1: u64[4]
+"""
 
 
 class ElevationGroupJSON(typing.TypedDict):
@@ -11,8 +22,9 @@ class ElevationGroupJSON(typing.TypedDict):
     ltv_pct: int
     liquidation_threshold_pct: int
     allow_new_loans: int
-    reserved: list[int]
-    padding: list[int]
+    max_reserves_as_collateral: int
+    padding_0: int
+    padding_1: list[int]
 
 
 @dataclass
@@ -23,16 +35,20 @@ class ElevationGroup:
         "ltv_pct" / borsh.U8,
         "liquidation_threshold_pct" / borsh.U8,
         "allow_new_loans" / borsh.U8,
-        "reserved" / borsh.U8[2],
-        "padding" / borsh.U64[8],
+        "max_reserves_as_collateral" / borsh.U8,
+        "padding_0" / borsh.U8,
+        "debt_reserve" / BorshPubkey,
+        "padding_1" / borsh.U64[4],
     )
     max_liquidation_bonus_bps: int
     id: int
     ltv_pct: int
     liquidation_threshold_pct: int
     allow_new_loans: int
-    reserved: list[int]
-    padding: list[int]
+    max_reserves_as_collateral: int
+    padding_0: int
+    debt_reserve: str
+    padding_1: list[int]
 
     @classmethod
     def from_decoded(cls, obj: Container) -> "ElevationGroup":
@@ -42,8 +58,10 @@ class ElevationGroup:
             ltv_pct=obj.ltv_pct,
             liquidation_threshold_pct=obj.liquidation_threshold_pct,
             allow_new_loans=obj.allow_new_loans,
-            reserved=obj.reserved,
-            padding=obj.padding,
+            max_reserves_as_collateral=obj.max_reserves_as_collateral,
+            padding_0=obj.padding_0,
+            debt_reserve=obj.debt_reserve,
+            padding_1=obj.padding_1,
         )
 
     def to_encodable(self) -> dict[str, typing.Any]:
@@ -53,8 +71,10 @@ class ElevationGroup:
             "ltv_pct": self.ltv_pct,
             "liquidation_threshold_pct": self.liquidation_threshold_pct,
             "allow_new_loans": self.allow_new_loans,
-            "reserved": self.reserved,
-            "padding": self.padding,
+            "max_reserves_as_collateral": self.max_reserves_as_collateral,
+            "padding_0": self.padding_0,
+            "debt_reserve": self.debt_reserve,
+            "padding_1": self.padding_1,
         }
 
     def to_json(self) -> ElevationGroupJSON:
@@ -64,8 +84,10 @@ class ElevationGroup:
             "ltv_pct": self.ltv_pct,
             "liquidation_threshold_pct": self.liquidation_threshold_pct,
             "allow_new_loans": self.allow_new_loans,
-            "reserved": self.reserved,
-            "padding": self.padding,
+            "max_reserves_as_collateral": self.max_reserves_as_collateral,
+            "padding_0": self.padding_0,
+            "debt_reserve": self.debt_reserve,
+            "padding_1": self.padding_1,
         }
 
     @classmethod
@@ -76,6 +98,8 @@ class ElevationGroup:
             ltv_pct=obj["ltv_pct"],
             liquidation_threshold_pct=obj["liquidation_threshold_pct"],
             allow_new_loans=obj["allow_new_loans"],
-            reserved=obj["reserved"],
-            padding=obj["padding"],
+            max_reserves_as_collateral=obj["max_reserves_as_collateral"],
+            padding_0=obj["padding_0"],
+            debt_reserve=obj["debt_reserve"],
+            padding_1=obj["padding_1"],
         )

--- a/codegen_lend/lend_types/fee_calculation.py
+++ b/codegen_lend/lend_types/fee_calculation.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
+# Release 1.6.2
+# No change
+
 
 class ExclusiveJSON(typing.TypedDict):
     kind: typing.Literal["Exclusive"]

--- a/codegen_lend/lend_types/last_update.py
+++ b/codegen_lend/lend_types/last_update.py
@@ -4,32 +4,59 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Adapting to release 1.6.2
+
 
 class LastUpdateJSON(typing.TypedDict):
     slot: int
     stale: bool
+    price_status: int
     placeholder: list[int]
 
 
 @dataclass
 class LastUpdate:
     layout: typing.ClassVar = borsh.CStruct(
-        "slot" / borsh.U64, "stale" / borsh.Bool, "placeholder" / borsh.U8[7]
+        "slot" / borsh.U64,
+        "stale" / borsh.Bool,
+        "price_status" / borsh.U8,
+        "placeholder" / borsh.U8[6],
     )
     slot: int
     stale: bool
+    price_status: int
     placeholder: list[int]
 
     @classmethod
     def from_decoded(cls, obj: Container) -> "LastUpdate":
-        return cls(slot=obj.slot, stale=obj.stale, placeholder=obj.placeholder)
+        return cls(
+            slot=obj.slot,
+            stale=obj.stale,
+            price_status=obj.price_status,
+            placeholder=obj.placeholder,
+        )
 
     def to_encodable(self) -> dict[str, typing.Any]:
-        return {"slot": self.slot, "stale": self.stale, "placeholder": self.placeholder}
+        return {
+            "slot": self.slot,
+            "stale": self.stale,
+            "price_status": self.price_status,
+            "placeholder": self.placeholder,
+        }
 
     def to_json(self) -> LastUpdateJSON:
-        return {"slot": self.slot, "stale": self.stale, "placeholder": self.placeholder}
+        return {
+            "slot": self.slot,
+            "stale": self.stale,
+            "price_status": self.price_status,
+            "placeholder": self.placeholder,
+        }
 
     @classmethod
     def from_json(cls, obj: LastUpdateJSON) -> "LastUpdate":
-        return cls(slot=obj["slot"], stale=obj["stale"], placeholder=obj["placeholder"])
+        return cls(
+            slot=obj["slot"],
+            stale=obj["stale"],
+            price_status=obj["price_status"],
+            placeholder=obj["placeholder"],
+        )

--- a/codegen_lend/lend_types/obligation_collateral.py
+++ b/codegen_lend/lend_types/obligation_collateral.py
@@ -7,24 +7,31 @@ from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
 
+# Adapting to release 1.6.2
+
+
 class ObligationCollateralJSON(typing.TypedDict):
     deposit_reserve: str
     deposited_amount: int
     market_value_sf: int
+    borrowed_amount_against_this_collateral_in_elevation_group: int
     padding: list[int]
 
 
 @dataclass
 class ObligationCollateral:
+
     layout: typing.ClassVar = borsh.CStruct(
         "deposit_reserve" / BorshPubkey,
         "deposited_amount" / borsh.U64,
         "market_value_sf" / borsh.U128,
-        "padding" / borsh.U64[10],
+        "borrowed_amount_against_this_collateral_in_elevation_group" / borsh.U64,
+        "padding" / borsh.U64[9],
     )
     deposit_reserve: Pubkey
     deposited_amount: int
     market_value_sf: int
+    borrowed_amount_against_this_collateral_in_elevation_group: int
     padding: list[int]
 
     @classmethod
@@ -33,6 +40,7 @@ class ObligationCollateral:
             deposit_reserve=obj.deposit_reserve,
             deposited_amount=obj.deposited_amount,
             market_value_sf=obj.market_value_sf,
+            borrowed_amount_against_this_collateral_in_elevation_group=obj.borrowed_amount_against_this_collateral_in_elevation_group,
             padding=obj.padding,
         )
 
@@ -41,6 +49,7 @@ class ObligationCollateral:
             "deposit_reserve": self.deposit_reserve,
             "deposited_amount": self.deposited_amount,
             "market_value_sf": self.market_value_sf,
+            "borrowed_amount_against_this_collateral_in_elevation_group": self.borrowed_amount_against_this_collateral_in_elevation_group,
             "padding": self.padding,
         }
 
@@ -49,6 +58,7 @@ class ObligationCollateral:
             "deposit_reserve": str(self.deposit_reserve),
             "deposited_amount": self.deposited_amount,
             "market_value_sf": self.market_value_sf,
+            "borrowed_amount_against_this_collateral_in_elevation_group": self.borrowed_amount_against_this_collateral_in_elevation_group,
             "padding": self.padding,
         }
 
@@ -58,5 +68,8 @@ class ObligationCollateral:
             deposit_reserve=Pubkey.from_string(obj["deposit_reserve"]),
             deposited_amount=obj["deposited_amount"],
             market_value_sf=obj["market_value_sf"],
+            borrowed_amount_against_this_collateral_in_elevation_group=obj[
+                "borrowed_amount_against_this_collateral_in_elevation_group"
+            ],
             padding=obj["padding"],
         )

--- a/codegen_lend/lend_types/obligation_liquidity.py
+++ b/codegen_lend/lend_types/obligation_liquidity.py
@@ -9,7 +9,16 @@ from solders.pubkey import Pubkey
 from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
+# Adapted to release 1.6.2
 
+"""
+borrowed_amount_outside_elevation_groups: u64
+
+padding2 -> 8 to 7
+"""
+
+
+# Done
 class ObligationLiquidityJSON(typing.TypedDict):
     borrow_reserve: str
     cumulative_borrow_rate_bsf: big_fraction_bytes.BigFractionBytesJSON
@@ -17,6 +26,7 @@ class ObligationLiquidityJSON(typing.TypedDict):
     borrowed_amount_sf: int
     market_value_sf: int
     borrow_factor_adjusted_market_value_sf: int
+    borrowed_amount_outside_elevation_groups: int
     padding2: list[int]
 
 
@@ -29,14 +39,17 @@ class ObligationLiquidity:
         "borrowed_amount_sf" / borsh.U128,
         "market_value_sf" / borsh.U128,
         "borrow_factor_adjusted_market_value_sf" / borsh.U128,
-        "padding2" / borsh.U64[8],
+        "borrowed_amount_outside_elevation_groups" / borsh.U64,
+        "padding2" / borsh.U64[7],
     )
+
     borrow_reserve: Pubkey
     cumulative_borrow_rate_bsf: big_fraction_bytes.BigFractionBytes
     padding: int
     borrowed_amount_sf: int
     market_value_sf: int
     borrow_factor_adjusted_market_value_sf: int
+    borrowed_amount_outside_elevation_groups: int
     padding2: list[int]
 
     @classmethod
@@ -50,6 +63,7 @@ class ObligationLiquidity:
             borrowed_amount_sf=obj.borrowed_amount_sf,
             market_value_sf=obj.market_value_sf,
             borrow_factor_adjusted_market_value_sf=obj.borrow_factor_adjusted_market_value_sf,
+            borrowed_amount_outside_elevation_groups=obj.borrowed_amount_outside_elevation_groups,
             padding2=obj.padding2,
         )
 
@@ -61,6 +75,7 @@ class ObligationLiquidity:
             "borrowed_amount_sf": self.borrowed_amount_sf,
             "market_value_sf": self.market_value_sf,
             "borrow_factor_adjusted_market_value_sf": self.borrow_factor_adjusted_market_value_sf,
+            "borrowed_amount_outside_elevation_groups": self.borrowed_amount_outside_elevation_groups,
             "padding2": self.padding2,
         }
 
@@ -72,6 +87,7 @@ class ObligationLiquidity:
             "borrowed_amount_sf": self.borrowed_amount_sf,
             "market_value_sf": self.market_value_sf,
             "borrow_factor_adjusted_market_value_sf": self.borrow_factor_adjusted_market_value_sf,
+            "borrowed_amount_outside_elevation_groups": self.borrowed_amount_outside_elevation_groups,
             "padding2": self.padding2,
         }
 
@@ -87,6 +103,9 @@ class ObligationLiquidity:
             market_value_sf=obj["market_value_sf"],
             borrow_factor_adjusted_market_value_sf=obj[
                 "borrow_factor_adjusted_market_value_sf"
+            ],
+            borrowed_amount_outside_elevation_groups=obj[
+                "borrowed_amount_outside_elevation_groups"
             ],
             padding2=obj["padding2"],
         )

--- a/codegen_lend/lend_types/price_heuristic.py
+++ b/codegen_lend/lend_types/price_heuristic.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class PriceHeuristicJSON(typing.TypedDict):
     lower: int

--- a/codegen_lend/lend_types/pyth_configuration.py
+++ b/codegen_lend/lend_types/pyth_configuration.py
@@ -6,6 +6,8 @@ from solders.pubkey import Pubkey
 from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
+# Release 1.6.2: No Change
+
 
 class PythConfigurationJSON(typing.TypedDict):
     price: str

--- a/codegen_lend/lend_types/required_ix_type.py
+++ b/codegen_lend/lend_types/required_ix_type.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class RefreshReserveJSON(typing.TypedDict):
     kind: typing.Literal["RefreshReserve"]

--- a/codegen_lend/lend_types/reserve_collateral.py
+++ b/codegen_lend/lend_types/reserve_collateral.py
@@ -6,6 +6,8 @@ from solders.pubkey import Pubkey
 from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class ReserveCollateralJSON(typing.TypedDict):
     mint_pubkey: str

--- a/codegen_lend/lend_types/reserve_config.py
+++ b/codegen_lend/lend_types/reserve_config.py
@@ -11,10 +11,24 @@ from construct import Container
 import borsh_construct as borsh
 
 
+# Adapted for release 1.6.2
+
+"""
+remove reserved0 put -> host_fixed_interest_rate_bps: u16,
+
+
+change reserved1 -> reserved_1 and from 4 to 2
+disable_usage_as_coll_outside_emode: u8,
+utilization_limit_block_borrowing_above: u8,
+borrow_limit_outside_elevation_group: u64,
+borrow_limit_against_this_collateral_in_elevation_group: [u64; 32],
+"""
+
+
 class ReserveConfigJSON(typing.TypedDict):
     status: int
     asset_tier: int
-    reserved0: list[int]
+    host_fixed_interest_rate_bps: int
     multiplier_side_boost: list[int]
     multiplier_tag_boost: list[int]
     protocol_take_rate_pct: int
@@ -35,7 +49,11 @@ class ReserveConfigJSON(typing.TypedDict):
     deposit_withdrawal_cap: withdrawal_caps.WithdrawalCapsJSON
     debt_withdrawal_cap: withdrawal_caps.WithdrawalCapsJSON
     elevation_groups: list[int]
-    reserved1: list[int]
+    reserved_1: list[int]
+    disable_usage_as_coll_outside_emode: int
+    utilization_limit_block_borrowing_above: int
+    borrow_limit_outside_elevation_group: int
+    borrow_limit_against_this_collateral_in_elevation_group: list[int]
 
 
 @dataclass
@@ -43,7 +61,7 @@ class ReserveConfig:
     layout: typing.ClassVar = borsh.CStruct(
         "status" / borsh.U8,
         "asset_tier" / borsh.U8,
-        "reserved0" / borsh.U8[2],
+        "host_fixed_interest_rate_bps" / borsh.U16,
         "multiplier_side_boost" / borsh.U8[2],
         "multiplier_tag_boost" / borsh.U8[8],
         "protocol_take_rate_pct" / borsh.U8,
@@ -64,11 +82,15 @@ class ReserveConfig:
         "deposit_withdrawal_cap" / withdrawal_caps.WithdrawalCaps.layout,
         "debt_withdrawal_cap" / withdrawal_caps.WithdrawalCaps.layout,
         "elevation_groups" / borsh.U8[20],
-        "reserved1" / borsh.U8[4],
+        "disable_usage_as_coll_outside_emode" / borsh.U8,
+        "utilization_limit_block_borrowing_above" / borsh.U8,
+        "reserved_1" / borsh.U8[2],
+        "borrow_limit_outside_elevation_group" / borsh.U64,
+        "borrow_limit_against_this_collateral_in_elevation_group" / borsh.U64[32],
     )
     status: int
     asset_tier: int
-    reserved0: list[int]
+    host_fixed_interest_rate_bps: int
     multiplier_side_boost: list[int]
     multiplier_tag_boost: list[int]
     protocol_take_rate_pct: int
@@ -89,14 +111,18 @@ class ReserveConfig:
     deposit_withdrawal_cap: withdrawal_caps.WithdrawalCaps
     debt_withdrawal_cap: withdrawal_caps.WithdrawalCaps
     elevation_groups: list[int]
-    reserved1: list[int]
+    disable_usage_as_coll_outside_emode: int
+    utilization_limit_block_borrowing_above: int
+    reserved_1: list[int]
+    borrow_limit_outside_elevation_group: int
+    borrow_limit_against_this_collateral_in_elevation_group: list[int]
 
     @classmethod
     def from_decoded(cls, obj: Container) -> "ReserveConfig":
         return cls(
             status=obj.status,
             asset_tier=obj.asset_tier,
-            reserved0=obj.reserved0,
+            host_fixed_interest_rate_bps=obj.host_fixed_interest_rate_bps,
             multiplier_side_boost=obj.multiplier_side_boost,
             multiplier_tag_boost=obj.multiplier_tag_boost,
             protocol_take_rate_pct=obj.protocol_take_rate_pct,
@@ -123,14 +149,18 @@ class ReserveConfig:
                 obj.debt_withdrawal_cap
             ),
             elevation_groups=obj.elevation_groups,
-            reserved1=obj.reserved1,
+            reserved_1=obj.reserved_1,
+            disable_usage_as_coll_outside_emode=obj.disable_usage_as_coll_outside_emode,
+            utilization_limit_block_borrowing_above=obj.utilization_limit_block_borrowing_above,
+            borrow_limit_outside_elevation_group=obj.borrow_limit_outside_elevation_group,
+            borrow_limit_against_this_collateral_in_elevation_group=obj.borrow_limit_against_this_collateral_in_elevation_group,
         )
 
     def to_encodable(self) -> dict[str, typing.Any]:
         return {
             "status": self.status,
             "asset_tier": self.asset_tier,
-            "reserved0": self.reserved0,
+            "host_fixed_interest_rate_bps": self.host_fixed_interest_rate_bps,
             "multiplier_side_boost": self.multiplier_side_boost,
             "multiplier_tag_boost": self.multiplier_tag_boost,
             "protocol_take_rate_pct": self.protocol_take_rate_pct,
@@ -151,14 +181,18 @@ class ReserveConfig:
             "deposit_withdrawal_cap": self.deposit_withdrawal_cap.to_encodable(),
             "debt_withdrawal_cap": self.debt_withdrawal_cap.to_encodable(),
             "elevation_groups": self.elevation_groups,
-            "reserved1": self.reserved1,
+            "reserved_1": self.reserved_1,
+            "disable_usage_as_coll_outside_emode": self.disable_usage_as_coll_outside_emode,
+            "utilization_limit_block_borrowing_above": self.utilization_limit_block_borrowing_above,
+            "borrow_limit_outside_elevation_group": self.borrow_limit_outside_elevation_group,
+            "borrow_limit_against_this_collateral_in_elevation_group": self.borrow_limit_against_this_collateral_in_elevation_group,
         }
 
     def to_json(self) -> ReserveConfigJSON:
         return {
             "status": self.status,
             "asset_tier": self.asset_tier,
-            "reserved0": self.reserved0,
+            "host_fixed_interest_rate_bps": self.host_fixed_interest_rate_bps,
             "multiplier_side_boost": self.multiplier_side_boost,
             "multiplier_tag_boost": self.multiplier_tag_boost,
             "protocol_take_rate_pct": self.protocol_take_rate_pct,
@@ -179,7 +213,11 @@ class ReserveConfig:
             "deposit_withdrawal_cap": self.deposit_withdrawal_cap.to_json(),
             "debt_withdrawal_cap": self.debt_withdrawal_cap.to_json(),
             "elevation_groups": self.elevation_groups,
-            "reserved1": self.reserved1,
+            "reserved_1": self.reserved_1,
+            "disable_usage_as_coll_outside_emode": self.disable_usage_as_coll_outside_emode,
+            "utilization_limit_block_borrowing_above": self.utilization_limit_block_borrowing_above,
+            "borrow_limit_outside_elevation_group": self.borrow_limit_outside_elevation_group,
+            "borrow_limit_against_this_collateral_in_elevation_group": self.borrow_limit_against_this_collateral_in_elevation_group,
         }
 
     @classmethod
@@ -187,7 +225,7 @@ class ReserveConfig:
         return cls(
             status=obj["status"],
             asset_tier=obj["asset_tier"],
-            reserved0=obj["reserved0"],
+            host_fixed_interest_rate_bps=obj["host_fixed_interest_rate_bps"],
             multiplier_side_boost=obj["multiplier_side_boost"],
             multiplier_tag_boost=obj["multiplier_tag_boost"],
             protocol_take_rate_pct=obj["protocol_take_rate_pct"],
@@ -218,5 +256,17 @@ class ReserveConfig:
                 obj["debt_withdrawal_cap"]
             ),
             elevation_groups=obj["elevation_groups"],
-            reserved1=obj["reserved1"],
+            reserved_1=obj["reserved_1"],
+            disable_usage_as_coll_outside_emode=obj[
+                "disable_usage_as_coll_outside_emode"
+            ],
+            utilization_limit_block_borrowing_above=obj[
+                "utilization_limit_block_borrowing_above"
+            ],
+            borrow_limit_outside_elevation_group=obj[
+                "borrow_limit_outside_elevation_group"
+            ],
+            borrow_limit_against_this_collateral_in_elevation_group=obj[
+                "borrow_limit_against_this_collateral_in_elevation_group"
+            ],
         )

--- a/codegen_lend/lend_types/reserve_farm_kind.py
+++ b/codegen_lend/lend_types/reserve_farm_kind.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
+# Release 1.6.2: no change
+
 
 class CollateralJSON(typing.TypedDict):
     kind: typing.Literal["Collateral"]

--- a/codegen_lend/lend_types/reserve_fees.py
+++ b/codegen_lend/lend_types/reserve_fees.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class ReserveFeesJSON(typing.TypedDict):
     borrow_fee_sf: int

--- a/codegen_lend/lend_types/reserve_liquidity.py
+++ b/codegen_lend/lend_types/reserve_liquidity.py
@@ -10,6 +10,15 @@ from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
 
+# Adapted to release 1.6.2
+
+
+"""
+Adding token program
+padding2 -> 55 to 51
+"""
+
+
 class ReserveLiquidityJSON(typing.TypedDict):
     mint_pubkey: str
     supply_vault: str
@@ -26,6 +35,7 @@ class ReserveLiquidityJSON(typing.TypedDict):
     accumulated_referrer_fees_sf: int
     pending_referrer_fees_sf: int
     absolute_referral_rate_sf: int
+    token_program: str
     padding2: list[int]
     padding3: list[int]
 
@@ -48,7 +58,8 @@ class ReserveLiquidity:
         "accumulated_referrer_fees_sf" / borsh.U128,
         "pending_referrer_fees_sf" / borsh.U128,
         "absolute_referral_rate_sf" / borsh.U128,
-        "padding2" / borsh.U64[55],
+        "token_program" / BorshPubkey,
+        "padding2" / borsh.U64[51],
         "padding3" / borsh.U128[32],
     )
     mint_pubkey: Pubkey
@@ -66,6 +77,7 @@ class ReserveLiquidity:
     accumulated_referrer_fees_sf: int
     pending_referrer_fees_sf: int
     absolute_referral_rate_sf: int
+    token_program: Pubkey
     padding2: list[int]
     padding3: list[int]
 
@@ -89,6 +101,7 @@ class ReserveLiquidity:
             accumulated_referrer_fees_sf=obj.accumulated_referrer_fees_sf,
             pending_referrer_fees_sf=obj.pending_referrer_fees_sf,
             absolute_referral_rate_sf=obj.absolute_referral_rate_sf,
+            token_program=obj.token_program,
             padding2=obj.padding2,
             padding3=obj.padding3,
         )
@@ -110,6 +123,7 @@ class ReserveLiquidity:
             "accumulated_referrer_fees_sf": self.accumulated_referrer_fees_sf,
             "pending_referrer_fees_sf": self.pending_referrer_fees_sf,
             "absolute_referral_rate_sf": self.absolute_referral_rate_sf,
+            "token_program": self.token_program,
             "padding2": self.padding2,
             "padding3": self.padding3,
         }
@@ -131,6 +145,7 @@ class ReserveLiquidity:
             "accumulated_referrer_fees_sf": self.accumulated_referrer_fees_sf,
             "pending_referrer_fees_sf": self.pending_referrer_fees_sf,
             "absolute_referral_rate_sf": self.absolute_referral_rate_sf,
+            "token_program": self.token_program,
             "padding2": self.padding2,
             "padding3": self.padding3,
         }
@@ -155,6 +170,7 @@ class ReserveLiquidity:
             accumulated_referrer_fees_sf=obj["accumulated_referrer_fees_sf"],
             pending_referrer_fees_sf=obj["pending_referrer_fees_sf"],
             absolute_referral_rate_sf=obj["absolute_referral_rate_sf"],
+            token_program=obj["token_program"],
             padding2=obj["padding2"],
             padding3=obj["padding3"],
         )

--- a/codegen_lend/lend_types/reserve_status.py
+++ b/codegen_lend/lend_types/reserve_status.py
@@ -5,12 +5,20 @@ from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
 
+# Adapted for release 1.6.2
+# Adding Hidden
+
+
 class ActiveJSON(typing.TypedDict):
     kind: typing.Literal["Active"]
 
 
 class ObsoleteJSON(typing.TypedDict):
     kind: typing.Literal["Obsolete"]
+
+
+class HiddenJSON(typing.TypedDict):
+    kind: typing.Literal["Hidden"]
 
 
 @dataclass
@@ -49,8 +57,26 @@ class Obsolete:
         }
 
 
-ReserveStatusKind = typing.Union[Active, Obsolete]
-ReserveStatusJSON = typing.Union[ActiveJSON, ObsoleteJSON]
+@dataclass
+class Hidden:
+    discriminator: typing.ClassVar = 2
+    kind: typing.ClassVar = "Hidden"
+
+    @classmethod
+    def to_json(cls) -> ObsoleteJSON:
+        return ObsoleteJSON(
+            kind="Hidden",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Hidden": {},
+        }
+
+
+ReserveStatusKind = typing.Union[Active, Obsolete, Hidden]
+ReserveStatusJSON = typing.Union[ActiveJSON, ObsoleteJSON, HiddenJSON]
 
 
 def from_decoded(obj: dict) -> ReserveStatusKind:
@@ -60,6 +86,8 @@ def from_decoded(obj: dict) -> ReserveStatusKind:
         return Active()
     if "Obsolete" in obj:
         return Obsolete()
+    if "Hidden" in obj:
+        return Hidden()
     raise ValueError("Invalid enum object")
 
 
@@ -68,8 +96,13 @@ def from_json(obj: ReserveStatusJSON) -> ReserveStatusKind:
         return Active()
     if obj["kind"] == "Obsolete":
         return Obsolete()
-    kind = obj["kind"]
-    raise ValueError(f"Unrecognized enum kind: {kind}")
+    if obk["kind"] == "Hidden":
+        return Hidden()
+    raise ValueError(f"Unrecognized enum kind: {obj["kind"]}")
 
 
-layout = EnumForCodegen("Active" / borsh.CStruct(), "Obsolete" / borsh.CStruct())
+layout = EnumForCodegen(
+    "Active" / borsh.CStruct(),
+    "Obsolete" / borsh.CStruct(),
+    "Hidden" / borsh.CStruct(),
+)

--- a/codegen_lend/lend_types/scope_configuration.py
+++ b/codegen_lend/lend_types/scope_configuration.py
@@ -7,6 +7,9 @@ from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
 
+# Release 1.6.2: No change
+
+
 class ScopeConfigurationJSON(typing.TypedDict):
     price_feed: str
     price_chain: list[int]

--- a/codegen_lend/lend_types/switchboard_configuration.py
+++ b/codegen_lend/lend_types/switchboard_configuration.py
@@ -7,6 +7,9 @@ from anchorpy.borsh_extension import BorshPubkey
 import borsh_construct as borsh
 
 
+# Release 1.6.2: No change
+
+
 class SwitchboardConfigurationJSON(typing.TypedDict):
     price_aggregator: str
     twap_aggregator: str

--- a/codegen_lend/lend_types/token_info.py
+++ b/codegen_lend/lend_types/token_info.py
@@ -11,6 +11,14 @@ from construct import Container
 import borsh_construct as borsh
 
 
+# Adapting for release 1.6.2
+"""
+block_price_usage: u8
+reserved: u8[7]
+padding -> padding: u64[19]
+"""
+
+
 class TokenInfoJSON(typing.TypedDict):
     name: list[int]
     heuristic: price_heuristic.PriceHeuristicJSON
@@ -20,6 +28,8 @@ class TokenInfoJSON(typing.TypedDict):
     scope_configuration: scope_configuration.ScopeConfigurationJSON
     switchboard_configuration: switchboard_configuration.SwitchboardConfigurationJSON
     pyth_configuration: pyth_configuration.PythConfigurationJSON
+    block_price_usage: int
+    reserved: list[int]
     padding: list[int]
 
 
@@ -35,7 +45,9 @@ class TokenInfo:
         "switchboard_configuration"
         / switchboard_configuration.SwitchboardConfiguration.layout,
         "pyth_configuration" / pyth_configuration.PythConfiguration.layout,
-        "padding" / borsh.U64[20],
+        "block_price_usage" / borsh.U8,
+        "reserved" / borsh.U8[7],
+        "padding" / borsh.U64[19],
     )
     name: list[int]
     heuristic: price_heuristic.PriceHeuristic
@@ -45,6 +57,8 @@ class TokenInfo:
     scope_configuration: scope_configuration.ScopeConfiguration
     switchboard_configuration: switchboard_configuration.SwitchboardConfiguration
     pyth_configuration: pyth_configuration.PythConfiguration
+    block_price_usage: int
+    reserved: list[int]
     padding: list[int]
 
     @classmethod
@@ -64,6 +78,8 @@ class TokenInfo:
             pyth_configuration=pyth_configuration.PythConfiguration.from_decoded(
                 obj.pyth_configuration
             ),
+            block_price_usage=obj.block_price_usage,
+            reserved=obj.reserved,
             padding=obj.padding,
         )
 
@@ -77,6 +93,8 @@ class TokenInfo:
             "scope_configuration": self.scope_configuration.to_encodable(),
             "switchboard_configuration": self.switchboard_configuration.to_encodable(),
             "pyth_configuration": self.pyth_configuration.to_encodable(),
+            "block_price_usage": self.block_price_usage,
+            "reserved": self.reserved,
             "padding": self.padding,
         }
 
@@ -90,6 +108,8 @@ class TokenInfo:
             "scope_configuration": self.scope_configuration.to_json(),
             "switchboard_configuration": self.switchboard_configuration.to_json(),
             "pyth_configuration": self.pyth_configuration.to_json(),
+            "block_price_usage": self.block_price_usage,
+            "reserved": self.reserved,
             "padding": self.padding,
         }
 
@@ -110,5 +130,7 @@ class TokenInfo:
             pyth_configuration=pyth_configuration.PythConfiguration.from_json(
                 obj["pyth_configuration"]
             ),
+            block_price_usage=obj["block_price_usage"],
+            reserved=obj["reserved"],
             padding=obj["padding"],
         )

--- a/codegen_lend/lend_types/update_config_mode.py
+++ b/codegen_lend/lend_types/update_config_mode.py
@@ -4,6 +4,12 @@ from dataclasses import dataclass
 from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
+# Adapting for release 1.6.2
+
+# added UpdateFarmCollateral, UpdateFarmDebt, UpdateDisableUsageAsCollateralOutsideEmode, UpdateBlockBorrowingAboveUtilization, UpdateBlockPriceUsage, UpdateBorrowLimitOutsideElevationGroup, UpdateBorrowLimitsInElevationGroupAgainstThisReserve, UpdateHostFixedInterestRateBps
+
+# Fixing and adding values
+
 
 class UpdateLoanToValuePctJSON(typing.TypedDict):
     kind: typing.Literal["UpdateLoanToValuePct"]
@@ -161,9 +167,41 @@ class UpdateReserveStatusJSON(typing.TypedDict):
     kind: typing.Literal["UpdateReserveStatus"]
 
 
+class UpdateFarmCollateralJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFarmCollateral"]
+
+
+class UpdateFarmDebtJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFarmDebt"]
+
+
+class UpdateDisableUsageAsCollateralOutsideEmodeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDisableUsageAsCollateralOutsideEmode"]
+
+
+class UpdateBlockBorrowingAboveUtilizationJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBlockBorrowingAboveUtilization"]
+
+
+class UpdateBlockPriceUsageJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBlockPriceUsage"]
+
+
+class UpdateBorrowLimitOutsideElevationGroupJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowLimitOutsideElevationGroup"]
+
+
+class UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowLimitsInElevationGroupAgainstThisReserve"]
+
+
+class UpdateHostFixedInterestRateBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateHostFixedInterestRateBps"]
+
+
 @dataclass
 class UpdateLoanToValuePct:
-    discriminator: typing.ClassVar = 0
+    discriminator: typing.ClassVar = 1
     kind: typing.ClassVar = "UpdateLoanToValuePct"
 
     @classmethod
@@ -181,7 +219,7 @@ class UpdateLoanToValuePct:
 
 @dataclass
 class UpdateMaxLiquidationBonusBps:
-    discriminator: typing.ClassVar = 1
+    discriminator: typing.ClassVar = 2
     kind: typing.ClassVar = "UpdateMaxLiquidationBonusBps"
 
     @classmethod
@@ -199,7 +237,7 @@ class UpdateMaxLiquidationBonusBps:
 
 @dataclass
 class UpdateLiquidationThresholdPct:
-    discriminator: typing.ClassVar = 2
+    discriminator: typing.ClassVar = 3
     kind: typing.ClassVar = "UpdateLiquidationThresholdPct"
 
     @classmethod
@@ -217,7 +255,7 @@ class UpdateLiquidationThresholdPct:
 
 @dataclass
 class UpdateProtocolLiquidationFee:
-    discriminator: typing.ClassVar = 3
+    discriminator: typing.ClassVar = 4
     kind: typing.ClassVar = "UpdateProtocolLiquidationFee"
 
     @classmethod
@@ -235,7 +273,7 @@ class UpdateProtocolLiquidationFee:
 
 @dataclass
 class UpdateProtocolTakeRate:
-    discriminator: typing.ClassVar = 4
+    discriminator: typing.ClassVar = 5
     kind: typing.ClassVar = "UpdateProtocolTakeRate"
 
     @classmethod
@@ -253,7 +291,7 @@ class UpdateProtocolTakeRate:
 
 @dataclass
 class UpdateFeesBorrowFee:
-    discriminator: typing.ClassVar = 5
+    discriminator: typing.ClassVar = 6
     kind: typing.ClassVar = "UpdateFeesBorrowFee"
 
     @classmethod
@@ -271,7 +309,7 @@ class UpdateFeesBorrowFee:
 
 @dataclass
 class UpdateFeesFlashLoanFee:
-    discriminator: typing.ClassVar = 6
+    discriminator: typing.ClassVar = 7
     kind: typing.ClassVar = "UpdateFeesFlashLoanFee"
 
     @classmethod
@@ -289,7 +327,7 @@ class UpdateFeesFlashLoanFee:
 
 @dataclass
 class UpdateFeesReferralFeeBps:
-    discriminator: typing.ClassVar = 7
+    discriminator: typing.ClassVar = 8
     kind: typing.ClassVar = "UpdateFeesReferralFeeBps"
 
     @classmethod
@@ -307,7 +345,7 @@ class UpdateFeesReferralFeeBps:
 
 @dataclass
 class UpdateDepositLimit:
-    discriminator: typing.ClassVar = 8
+    discriminator: typing.ClassVar = 9
     kind: typing.ClassVar = "UpdateDepositLimit"
 
     @classmethod
@@ -325,7 +363,7 @@ class UpdateDepositLimit:
 
 @dataclass
 class UpdateBorrowLimit:
-    discriminator: typing.ClassVar = 9
+    discriminator: typing.ClassVar = 10
     kind: typing.ClassVar = "UpdateBorrowLimit"
 
     @classmethod
@@ -343,7 +381,7 @@ class UpdateBorrowLimit:
 
 @dataclass
 class UpdateTokenInfoLowerHeuristic:
-    discriminator: typing.ClassVar = 10
+    discriminator: typing.ClassVar = 11
     kind: typing.ClassVar = "UpdateTokenInfoLowerHeuristic"
 
     @classmethod
@@ -361,7 +399,7 @@ class UpdateTokenInfoLowerHeuristic:
 
 @dataclass
 class UpdateTokenInfoUpperHeuristic:
-    discriminator: typing.ClassVar = 11
+    discriminator: typing.ClassVar = 12
     kind: typing.ClassVar = "UpdateTokenInfoUpperHeuristic"
 
     @classmethod
@@ -379,7 +417,7 @@ class UpdateTokenInfoUpperHeuristic:
 
 @dataclass
 class UpdateTokenInfoExpHeuristic:
-    discriminator: typing.ClassVar = 12
+    discriminator: typing.ClassVar = 13
     kind: typing.ClassVar = "UpdateTokenInfoExpHeuristic"
 
     @classmethod
@@ -397,7 +435,7 @@ class UpdateTokenInfoExpHeuristic:
 
 @dataclass
 class UpdateTokenInfoTwapDivergence:
-    discriminator: typing.ClassVar = 13
+    discriminator: typing.ClassVar = 14
     kind: typing.ClassVar = "UpdateTokenInfoTwapDivergence"
 
     @classmethod
@@ -415,7 +453,7 @@ class UpdateTokenInfoTwapDivergence:
 
 @dataclass
 class UpdateTokenInfoScopeTwap:
-    discriminator: typing.ClassVar = 14
+    discriminator: typing.ClassVar = 15
     kind: typing.ClassVar = "UpdateTokenInfoScopeTwap"
 
     @classmethod
@@ -433,7 +471,7 @@ class UpdateTokenInfoScopeTwap:
 
 @dataclass
 class UpdateTokenInfoScopeChain:
-    discriminator: typing.ClassVar = 15
+    discriminator: typing.ClassVar = 16
     kind: typing.ClassVar = "UpdateTokenInfoScopeChain"
 
     @classmethod
@@ -451,7 +489,7 @@ class UpdateTokenInfoScopeChain:
 
 @dataclass
 class UpdateTokenInfoName:
-    discriminator: typing.ClassVar = 16
+    discriminator: typing.ClassVar = 17
     kind: typing.ClassVar = "UpdateTokenInfoName"
 
     @classmethod
@@ -469,7 +507,7 @@ class UpdateTokenInfoName:
 
 @dataclass
 class UpdateTokenInfoPriceMaxAge:
-    discriminator: typing.ClassVar = 17
+    discriminator: typing.ClassVar = 18
     kind: typing.ClassVar = "UpdateTokenInfoPriceMaxAge"
 
     @classmethod
@@ -487,7 +525,7 @@ class UpdateTokenInfoPriceMaxAge:
 
 @dataclass
 class UpdateTokenInfoTwapMaxAge:
-    discriminator: typing.ClassVar = 18
+    discriminator: typing.ClassVar = 19
     kind: typing.ClassVar = "UpdateTokenInfoTwapMaxAge"
 
     @classmethod
@@ -505,7 +543,7 @@ class UpdateTokenInfoTwapMaxAge:
 
 @dataclass
 class UpdateScopePriceFeed:
-    discriminator: typing.ClassVar = 19
+    discriminator: typing.ClassVar = 20
     kind: typing.ClassVar = "UpdateScopePriceFeed"
 
     @classmethod
@@ -523,7 +561,7 @@ class UpdateScopePriceFeed:
 
 @dataclass
 class UpdatePythPrice:
-    discriminator: typing.ClassVar = 20
+    discriminator: typing.ClassVar = 21
     kind: typing.ClassVar = "UpdatePythPrice"
 
     @classmethod
@@ -541,7 +579,7 @@ class UpdatePythPrice:
 
 @dataclass
 class UpdateSwitchboardFeed:
-    discriminator: typing.ClassVar = 21
+    discriminator: typing.ClassVar = 22
     kind: typing.ClassVar = "UpdateSwitchboardFeed"
 
     @classmethod
@@ -559,7 +597,7 @@ class UpdateSwitchboardFeed:
 
 @dataclass
 class UpdateSwitchboardTwapFeed:
-    discriminator: typing.ClassVar = 22
+    discriminator: typing.ClassVar = 23
     kind: typing.ClassVar = "UpdateSwitchboardTwapFeed"
 
     @classmethod
@@ -577,7 +615,7 @@ class UpdateSwitchboardTwapFeed:
 
 @dataclass
 class UpdateBorrowRateCurve:
-    discriminator: typing.ClassVar = 23
+    discriminator: typing.ClassVar = 24
     kind: typing.ClassVar = "UpdateBorrowRateCurve"
 
     @classmethod
@@ -595,7 +633,7 @@ class UpdateBorrowRateCurve:
 
 @dataclass
 class UpdateEntireReserveConfig:
-    discriminator: typing.ClassVar = 24
+    discriminator: typing.ClassVar = 25
     kind: typing.ClassVar = "UpdateEntireReserveConfig"
 
     @classmethod
@@ -613,7 +651,7 @@ class UpdateEntireReserveConfig:
 
 @dataclass
 class UpdateDebtWithdrawalCap:
-    discriminator: typing.ClassVar = 25
+    discriminator: typing.ClassVar = 26
     kind: typing.ClassVar = "UpdateDebtWithdrawalCap"
 
     @classmethod
@@ -631,7 +669,7 @@ class UpdateDebtWithdrawalCap:
 
 @dataclass
 class UpdateDepositWithdrawalCap:
-    discriminator: typing.ClassVar = 26
+    discriminator: typing.ClassVar = 27
     kind: typing.ClassVar = "UpdateDepositWithdrawalCap"
 
     @classmethod
@@ -649,7 +687,7 @@ class UpdateDepositWithdrawalCap:
 
 @dataclass
 class UpdateDebtWithdrawalCapCurrentTotal:
-    discriminator: typing.ClassVar = 27
+    discriminator: typing.ClassVar = 28
     kind: typing.ClassVar = "UpdateDebtWithdrawalCapCurrentTotal"
 
     @classmethod
@@ -667,7 +705,7 @@ class UpdateDebtWithdrawalCapCurrentTotal:
 
 @dataclass
 class UpdateDepositWithdrawalCapCurrentTotal:
-    discriminator: typing.ClassVar = 28
+    discriminator: typing.ClassVar = 29
     kind: typing.ClassVar = "UpdateDepositWithdrawalCapCurrentTotal"
 
     @classmethod
@@ -685,7 +723,7 @@ class UpdateDepositWithdrawalCapCurrentTotal:
 
 @dataclass
 class UpdateBadDebtLiquidationBonusBps:
-    discriminator: typing.ClassVar = 29
+    discriminator: typing.ClassVar = 30
     kind: typing.ClassVar = "UpdateBadDebtLiquidationBonusBps"
 
     @classmethod
@@ -703,7 +741,7 @@ class UpdateBadDebtLiquidationBonusBps:
 
 @dataclass
 class UpdateMinLiquidationBonusBps:
-    discriminator: typing.ClassVar = 30
+    discriminator: typing.ClassVar = 31
     kind: typing.ClassVar = "UpdateMinLiquidationBonusBps"
 
     @classmethod
@@ -721,7 +759,7 @@ class UpdateMinLiquidationBonusBps:
 
 @dataclass
 class DeleveragingMarginCallPeriod:
-    discriminator: typing.ClassVar = 31
+    discriminator: typing.ClassVar = 32
     kind: typing.ClassVar = "DeleveragingMarginCallPeriod"
 
     @classmethod
@@ -739,7 +777,7 @@ class DeleveragingMarginCallPeriod:
 
 @dataclass
 class UpdateBorrowFactor:
-    discriminator: typing.ClassVar = 32
+    discriminator: typing.ClassVar = 33
     kind: typing.ClassVar = "UpdateBorrowFactor"
 
     @classmethod
@@ -757,7 +795,7 @@ class UpdateBorrowFactor:
 
 @dataclass
 class UpdateAssetTier:
-    discriminator: typing.ClassVar = 33
+    discriminator: typing.ClassVar = 34
     kind: typing.ClassVar = "UpdateAssetTier"
 
     @classmethod
@@ -775,7 +813,7 @@ class UpdateAssetTier:
 
 @dataclass
 class UpdateElevationGroup:
-    discriminator: typing.ClassVar = 34
+    discriminator: typing.ClassVar = 35
     kind: typing.ClassVar = "UpdateElevationGroup"
 
     @classmethod
@@ -793,7 +831,7 @@ class UpdateElevationGroup:
 
 @dataclass
 class DeleveragingThresholdSlotsPerBps:
-    discriminator: typing.ClassVar = 35
+    discriminator: typing.ClassVar = 36
     kind: typing.ClassVar = "DeleveragingThresholdSlotsPerBps"
 
     @classmethod
@@ -811,7 +849,7 @@ class DeleveragingThresholdSlotsPerBps:
 
 @dataclass
 class UpdateMultiplierSideBoost:
-    discriminator: typing.ClassVar = 36
+    discriminator: typing.ClassVar = 37
     kind: typing.ClassVar = "UpdateMultiplierSideBoost"
 
     @classmethod
@@ -829,7 +867,7 @@ class UpdateMultiplierSideBoost:
 
 @dataclass
 class UpdateMultiplierTagBoost:
-    discriminator: typing.ClassVar = 37
+    discriminator: typing.ClassVar = 38
     kind: typing.ClassVar = "UpdateMultiplierTagBoost"
 
     @classmethod
@@ -847,7 +885,7 @@ class UpdateMultiplierTagBoost:
 
 @dataclass
 class UpdateReserveStatus:
-    discriminator: typing.ClassVar = 38
+    discriminator: typing.ClassVar = 39
     kind: typing.ClassVar = "UpdateReserveStatus"
 
     @classmethod
@@ -860,6 +898,150 @@ class UpdateReserveStatus:
     def to_encodable(cls) -> dict:
         return {
             "UpdateReserveStatus": {},
+        }
+
+
+@dataclass
+class UpdateFarmCollateral:
+    discriminator: typing.ClassVar = 40
+    kind: typing.ClassVar = "UpdateFarmCollateral"
+
+    @classmethod
+    def to_json(cls) -> UpdateFarmCollateralJSON:
+        return UpdateFarmCollateralJSON(
+            kind="UpdateFarmCollateral",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFarmCollateral": {},
+        }
+
+
+@dataclass
+class UpdateFarmDebt:
+    discriminator: typing.ClassVar = 41
+    kind: typing.ClassVar = "UpdateFarmDebt"
+
+    @classmethod
+    def to_json(cls) -> UpdateFarmDebtJSON:
+        return UpdateFarmDebtJSON(
+            kind="UpdateFarmDebt",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFarmDebt": {},
+        }
+
+
+@dataclass
+class UpdateDisableUsageAsCollateralOutsideEmode:
+    discriminator: typing.ClassVar = 42
+    kind: typing.ClassVar = "UpdateDisableUsageAsCollateralOutsideEmode"
+
+    @classmethod
+    def to_json(cls) -> UpdateDisableUsageAsCollateralOutsideEmodeJSON:
+        return UpdateDisableUsageAsCollateralOutsideEmodeJSON(
+            kind="UpdateFarmDebt",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDisableUsageAsCollateralOutsideEmode": {},
+        }
+
+
+@dataclass
+class UpdateBlockBorrowingAboveUtilization:
+    discriminator: typing.ClassVar = 43
+    kind: typing.ClassVar = "UpdateBlockBorrowingAboveUtilization"
+
+    @classmethod
+    def to_json(cls) -> UpdateBlockBorrowingAboveUtilizationJSON:
+        return UpdateBlockBorrowingAboveUtilizationJSON(
+            kind="UpdateBlockBorrowingAboveUtilization",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBlockBorrowingAboveUtilization": {},
+        }
+
+
+@dataclass
+class UpdateBlockPriceUsage:
+    discriminator: typing.ClassVar = 44
+    kind: typing.ClassVar = "UpdateBlockPriceUsage"
+
+    @classmethod
+    def to_json(cls) -> UpdateBlockPriceUsageJSON:
+        return UpdateBlockPriceUsageJSON(
+            kind="UpdateBlockPriceUsage",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBlockPriceUsage": {},
+        }
+
+
+@dataclass
+class UpdateBorrowLimitOutsideElevationGroup:
+    discriminator: typing.ClassVar = 45
+    kind: typing.ClassVar = "UpdateBorrowLimitOutsideElevationGroup"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowLimitOutsideElevationGroupJSON:
+        return UpdateBorrowLimitOutsideElevationGroupJSON(
+            kind="UpdateBorrowLimitOutsideElevationGroup",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowLimitOutsideElevationGroup": {},
+        }
+
+
+@dataclass
+class UpdateBorrowLimitsInElevationGroupAgainstThisReserve:
+    discriminator: typing.ClassVar = 46
+    kind: typing.ClassVar = "UpdateBorrowLimitsInElevationGroupAgainstThisReserve"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON:
+        return UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON(
+            kind="UpdateBorrowLimitsInElevationGroupAgainstThisReserve",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowLimitsInElevationGroupAgainstThisReserve": {},
+        }
+
+
+@dataclass
+class UpdateHostFixedInterestRateBps:
+    discriminator: typing.ClassVar = 47
+    kind: typing.ClassVar = "UpdateHostFixedInterestRateBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateHostFixedInterestRateBpsJSON:
+        return UpdateHostFixedInterestRateBpsJSON(
+            kind="UpdateHostFixedInterestRateBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateHostFixedInterestRateBps": {},
         }
 
 
@@ -903,6 +1085,14 @@ UpdateConfigModeKind = typing.Union[
     UpdateMultiplierSideBoost,
     UpdateMultiplierTagBoost,
     UpdateReserveStatus,
+    UpdateFarmCollateral,
+    UpdateFarmDebt,
+    UpdateDisableUsageAsCollateralOutsideEmode,
+    UpdateBlockBorrowingAboveUtilization,
+    UpdateBlockPriceUsage,
+    UpdateBorrowLimitOutsideElevationGroup,
+    UpdateBorrowLimitsInElevationGroupAgainstThisReserve,
+    UpdateHostFixedInterestRateBps,
 ]
 UpdateConfigModeJSON = typing.Union[
     UpdateLoanToValuePctJSON,
@@ -944,6 +1134,14 @@ UpdateConfigModeJSON = typing.Union[
     UpdateMultiplierSideBoostJSON,
     UpdateMultiplierTagBoostJSON,
     UpdateReserveStatusJSON,
+    UpdateFarmCollateralJSON,
+    UpdateFarmDebtJSON,
+    UpdateDisableUsageAsCollateralOutsideEmodeJSON,
+    UpdateBlockBorrowingAboveUtilizationJSON,
+    UpdateBlockPriceUsageJSON,
+    UpdateBorrowLimitOutsideElevationGroupJSON,
+    UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON,
+    UpdateHostFixedInterestRateBpsJSON,
 ]
 
 
@@ -1028,6 +1226,22 @@ def from_decoded(obj: dict) -> UpdateConfigModeKind:
         return UpdateMultiplierTagBoost()
     if "UpdateReserveStatus" in obj:
         return UpdateReserveStatus()
+    if "UpdateFarmCollateral" in obj:
+        return UpdateFarmCollateral()
+    if "UpdateFarmDebt" in obj:
+        return UpdateFarmDebt()
+    if "UpdateDisableUsageAsCollateralOutsideEmode" in obj:
+        return UpdateDisableUsageAsCollateralOutsideEmode()
+    if "UpdateBlockBorrowingAboveUtilization" in obj:
+        return UpdateBlockBorrowingAboveUtilization()
+    if "UpdateBlockPriceUsage" in obj:
+        return UpdateBlockPriceUsage()
+    if "UpdateBorrowLimitOutsideElevationGroup" in obj:
+        return UpdateBorrowLimitOutsideElevationGroup()
+    if "UpdateBorrowLimitsInElevationGroupAgainstThisReserve" in obj:
+        return UpdateBorrowLimitsInElevationGroupAgainstThisReserve()
+    if "UpdateHostFixedInterestRateBps" in obj:
+        return UpdateHostFixedInterestRateBps()
     raise ValueError("Invalid enum object")
 
 
@@ -1110,8 +1324,23 @@ def from_json(obj: UpdateConfigModeJSON) -> UpdateConfigModeKind:
         return UpdateMultiplierTagBoost()
     if obj["kind"] == "UpdateReserveStatus":
         return UpdateReserveStatus()
-    kind = obj["kind"]
-    raise ValueError(f"Unrecognized enum kind: {kind}")
+    if obj["kind"] == "UpdateFarmCollateral":
+        return UpdateFarmCollateral()
+    if obj["kind"] == "UpdateFarmDebt":
+        return UpdateFarmDebt()
+    if obj["kind"] == "UpdateDisableUsageAsCollateralOutsideEmode":
+        return UpdateDisableUsageAsCollateralOutsideEmode()
+    if obj["kind"] == "UpdateBlockBorrowingAboveUtilization":
+        return UpdateBlockBorrowingAboveUtilization()
+    if obj["kind"] == "UpdateBlockPriceUsage":
+        return UpdateBlockPriceUsage()
+    if obj["kind"] == "UpdateBorrowLimitOutsideElevationGroup":
+        return UpdateBorrowLimitOutsideElevationGroup()
+    if obj["kind"] == "UpdateBorrowLimitsInElevationGroupAgainstThisReserve":
+        return UpdateBorrowLimitsInElevationGroupAgainstThisReserve()
+    if obj["kind"] == "UpdateHostFixedInterestRateBps":
+        return UpdateHostFixedInterestRateBps()
+    raise ValueError(f"Unrecognized enum kind: {obj["kind"]}")
 
 
 layout = EnumForCodegen(
@@ -1154,4 +1383,12 @@ layout = EnumForCodegen(
     "UpdateMultiplierSideBoost" / borsh.CStruct(),
     "UpdateMultiplierTagBoost" / borsh.CStruct(),
     "UpdateReserveStatus" / borsh.CStruct(),
+    "UpdateFarmCollateral" / borsh.CStruct(),
+    "UpdateFarmDebt" / borsh.CStruct(),
+    "UpdateDisableUsageAsCollateralOutsideEmode" / borsh.CStruct(),
+    "UpdateBlockBorrowingAboveUtilization" / borsh.CStruct(),
+    "UpdateBlockPriceUsage" / borsh.CStruct(),
+    "UpdateBorrowLimitOutsideElevationGroup" / borsh.CStruct(),
+    "UpdateBorrowLimitsInElevationGroupAgainstThisReserve" / borsh.CStruct(),
+    "UpdateHostFixedInterestRateBps" / borsh.CStruct(),
 )

--- a/codegen_lend/lend_types/update_lending_market_mode.py
+++ b/codegen_lend/lend_types/update_lending_market_mode.py
@@ -5,6 +5,10 @@ from anchorpy.borsh_extension import EnumForCodegen
 import borsh_construct as borsh
 
 
+# Adapted to release 1.6.2
+# Adding values
+
+
 class UpdateOwnerJSON(typing.TypedDict):
     kind: typing.Literal["UpdateOwner"]
 
@@ -55,6 +59,22 @@ class UpdateMultiplierPointsJSON(typing.TypedDict):
 
 class UpdatePriceRefreshTriggerToMaxAgePctJSON(typing.TypedDict):
     kind: typing.Literal["UpdatePriceRefreshTriggerToMaxAgePct"]
+
+
+class UpdateAutodeleverageEnabledJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateAutodeleverageEnabled"]
+
+
+class UpdateBorrowingDisabledJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowingDisabled"]
+
+
+class UpdateMinNetValueObligationPostActionJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMinNetValueObligationPostAction"]
+
+
+class UpdateMinValueSkipPriorityLiqCheckJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMinValueSkipPriorityLiqCheck"]
 
 
 @dataclass
@@ -291,6 +311,66 @@ class UpdatePriceRefreshTriggerToMaxAgePct:
         }
 
 
+@dataclass
+class UpdateAutodeleverageEnabled:
+    discriminator: typing.ClassVar = 13
+    kind: typing.ClassVar = "UpdateAutodeleverageEnabled"
+
+    @classmethod
+    def to_json(cls) -> UpdateAutodeleverageEnabledJSON:
+        return UpdateAutodeleverageEnabledJSON(
+            kind="UpdateAutodeleverageEnabled",
+        )
+
+    def to_encodable(self) -> dict:
+        return {"UpdateAutodeleverageEnabled": {}}
+
+
+@dataclass
+class UpdateBorrowingDisabled:
+    discriminator: typing.ClassVar = 14
+    kind: typing.ClassVar = "UpdateBorrowingDisabled"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowingDisabledJSON:
+        return UpdateBorrowingDisabledJSON(
+            kind="UpdateBorrowingDisabled",
+        )
+
+    def to_encodable(self) -> dict:
+        return {"UpdateBorrowingDisabled": {}}
+
+
+@dataclass
+class UpdateMinNetValueObligationPostAction:
+    discriminator: typing.ClassVar = 15
+    kind: typing.ClassVar = "UpdateMinNetValueObligationPostAction"
+
+    @classmethod
+    def to_json(cls) -> UpdateMinNetValueObligationPostActionJSON:
+        return UpdateMinNetValueObligationPostActionJSON(
+            kind="UpdateMinNetValueObligationPostAction",
+        )
+
+    def to_encodable(self) -> dict:
+        return {"UpdateMinNetValueObligationPostAction": {}}
+
+
+@dataclass
+class UpdateMinValueSkipPriorityLiqCheck:
+    discriminator: typing.ClassVar = 16
+    kind: typing.ClassVar = "UpdateMinValueSkipPriorityLiqCheck"
+
+    @classmethod
+    def to_json(cls) -> UpdateMinValueSkipPriorityLiqCheckJSON:
+        return UpdateMinValueSkipPriorityLiqCheckJSON(
+            kind="UpdateMinValueSkipPriorityLiqCheck",
+        )
+
+    def to_encodable(self) -> dict:
+        return {"UpdateMinValueSkipPriorityLiqCheck": {}}
+
+
 UpdateLendingMarketModeKind = typing.Union[
     UpdateOwner,
     UpdateEmergencyMode,
@@ -352,6 +432,14 @@ def from_decoded(obj: dict) -> UpdateLendingMarketModeKind:
         return UpdateMultiplierPoints()
     if "UpdatePriceRefreshTriggerToMaxAgePct" in obj:
         return UpdatePriceRefreshTriggerToMaxAgePct()
+    if "UpdateAutodeleverageEnabled" in obj:
+        return UpdateAutodeleverageEnabled()
+    if "UpdateBorrowingDisabled" in obj:
+        return UpdateBorrowingDisabled()
+    if "UpdateMinNetValueObligationPostAction" in obj:
+        return UpdateMinNetValueObligationPostAction()
+    if "UpdateMinValueSkipPriorityLiqCheck" in obj:
+        return UpdateMinValueSkipPriorityLiqCheck()
     raise ValueError("Invalid enum object")
 
 
@@ -382,8 +470,15 @@ def from_json(obj: UpdateLendingMarketModeJSON) -> UpdateLendingMarketModeKind:
         return UpdateMultiplierPoints()
     if obj["kind"] == "UpdatePriceRefreshTriggerToMaxAgePct":
         return UpdatePriceRefreshTriggerToMaxAgePct()
-    kind = obj["kind"]
-    raise ValueError(f"Unrecognized enum kind: {kind}")
+    if obj["kind"] == "UpdateAutodeleverageEnabled":
+        return UpdateAutodeleverageEnabled()
+    if obj["kind"] == "UpdateBorrowingDisabled":
+        return UpdateBorrowingDisabled()
+    if obj["kind"] == "UpdateMinNetValueObligationPostAction":
+        return UpdateMinNetValueObligationPostAction()
+    if obj["kind"] == "UpdateMinValueSkipPriorityLiqCheck":
+        return UpdateMinValueSkipPriorityLiqCheck()
+    raise ValueError(f"Unrecognized enum kind: {obj["kind"]}")
 
 
 layout = EnumForCodegen(
@@ -400,4 +495,8 @@ layout = EnumForCodegen(
     "UpdateReferralFeeBps" / borsh.CStruct(),
     "UpdateMultiplierPoints" / borsh.CStruct(),
     "UpdatePriceRefreshTriggerToMaxAgePct" / borsh.CStruct(),
+    "UpdateAutodeleverageEnabled" / borsh.CStruct(),
+    "UpdateBorrowingDisabled" / borsh.CStruct(),
+    "UpdateMinNetValueObligationPostAction" / borsh.CStruct(),
+    "UpdateMinValueSkipPriorityLiqCheck" / borsh.CStruct(),
 )

--- a/codegen_lend/lend_types/withdrawal_caps.py
+++ b/codegen_lend/lend_types/withdrawal_caps.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from construct import Container
 import borsh_construct as borsh
 
+# Release 1.6.2: No change
+
 
 class WithdrawalCapsJSON(typing.TypedDict):
     config_capacity: int

--- a/codegen_lend/types/__init__.py
+++ b/codegen_lend/types/__init__.py
@@ -1,0 +1,60 @@
+import typing
+from . import update_config_mode
+from .update_config_mode import UpdateConfigModeKind, UpdateConfigModeJSON
+from . import update_lending_market_config_value
+from .update_lending_market_config_value import (
+    UpdateLendingMarketConfigValueKind,
+    UpdateLendingMarketConfigValueJSON,
+)
+from . import update_lending_market_mode
+from .update_lending_market_mode import (
+    UpdateLendingMarketModeKind,
+    UpdateLendingMarketModeJSON,
+)
+from . import last_update
+from .last_update import LastUpdate, LastUpdateJSON
+from . import elevation_group
+from .elevation_group import ElevationGroup, ElevationGroupJSON
+from . import init_obligation_args
+from .init_obligation_args import InitObligationArgs, InitObligationArgsJSON
+from . import obligation_collateral
+from .obligation_collateral import ObligationCollateral, ObligationCollateralJSON
+from . import obligation_liquidity
+from .obligation_liquidity import ObligationLiquidity, ObligationLiquidityJSON
+from . import asset_tier
+from .asset_tier import AssetTierKind, AssetTierJSON
+from . import big_fraction_bytes
+from .big_fraction_bytes import BigFractionBytes, BigFractionBytesJSON
+from . import fee_calculation
+from .fee_calculation import FeeCalculationKind, FeeCalculationJSON
+from . import reserve_collateral
+from .reserve_collateral import ReserveCollateral, ReserveCollateralJSON
+from . import reserve_config
+from .reserve_config import ReserveConfig, ReserveConfigJSON
+from . import reserve_farm_kind
+from .reserve_farm_kind import ReserveFarmKindKind, ReserveFarmKindJSON
+from . import reserve_fees
+from .reserve_fees import ReserveFees, ReserveFeesJSON
+from . import reserve_liquidity
+from .reserve_liquidity import ReserveLiquidity, ReserveLiquidityJSON
+from . import reserve_status
+from .reserve_status import ReserveStatusKind, ReserveStatusJSON
+from . import withdrawal_caps
+from .withdrawal_caps import WithdrawalCaps, WithdrawalCapsJSON
+from . import price_heuristic
+from .price_heuristic import PriceHeuristic, PriceHeuristicJSON
+from . import pyth_configuration
+from .pyth_configuration import PythConfiguration, PythConfigurationJSON
+from . import scope_configuration
+from .scope_configuration import ScopeConfiguration, ScopeConfigurationJSON
+from . import switchboard_configuration
+from .switchboard_configuration import (
+    SwitchboardConfiguration,
+    SwitchboardConfigurationJSON,
+)
+from . import token_info
+from .token_info import TokenInfo, TokenInfoJSON
+from . import borrow_rate_curve
+from .borrow_rate_curve import BorrowRateCurve, BorrowRateCurveJSON
+from . import curve_point
+from .curve_point import CurvePoint, CurvePointJSON

--- a/codegen_lend/types/asset_tier.py
+++ b/codegen_lend/types/asset_tier.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
+
+
+class RegularJSON(typing.TypedDict):
+    kind: typing.Literal["Regular"]
+
+
+class IsolatedCollateralJSON(typing.TypedDict):
+    kind: typing.Literal["IsolatedCollateral"]
+
+
+class IsolatedDebtJSON(typing.TypedDict):
+    kind: typing.Literal["IsolatedDebt"]
+
+
+@dataclass
+class Regular:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "Regular"
+
+    @classmethod
+    def to_json(cls) -> RegularJSON:
+        return RegularJSON(
+            kind="Regular",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Regular": {},
+        }
+
+
+@dataclass
+class IsolatedCollateral:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "IsolatedCollateral"
+
+    @classmethod
+    def to_json(cls) -> IsolatedCollateralJSON:
+        return IsolatedCollateralJSON(
+            kind="IsolatedCollateral",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "IsolatedCollateral": {},
+        }
+
+
+@dataclass
+class IsolatedDebt:
+    discriminator: typing.ClassVar = 2
+    kind: typing.ClassVar = "IsolatedDebt"
+
+    @classmethod
+    def to_json(cls) -> IsolatedDebtJSON:
+        return IsolatedDebtJSON(
+            kind="IsolatedDebt",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "IsolatedDebt": {},
+        }
+
+
+AssetTierKind = typing.Union[Regular, IsolatedCollateral, IsolatedDebt]
+AssetTierJSON = typing.Union[RegularJSON, IsolatedCollateralJSON, IsolatedDebtJSON]
+
+
+def from_decoded(obj: dict) -> AssetTierKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "Regular" in obj:
+        return Regular()
+    if "IsolatedCollateral" in obj:
+        return IsolatedCollateral()
+    if "IsolatedDebt" in obj:
+        return IsolatedDebt()
+    raise ValueError("Invalid enum object")
+
+
+def from_json(obj: AssetTierJSON) -> AssetTierKind:
+    if obj["kind"] == "Regular":
+        return Regular()
+    if obj["kind"] == "IsolatedCollateral":
+        return IsolatedCollateral()
+    if obj["kind"] == "IsolatedDebt":
+        return IsolatedDebt()
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen(
+    "Regular" / borsh.CStruct(),
+    "IsolatedCollateral" / borsh.CStruct(),
+    "IsolatedDebt" / borsh.CStruct(),
+)

--- a/codegen_lend/types/big_fraction_bytes.py
+++ b/codegen_lend/types/big_fraction_bytes.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class BigFractionBytesJSON(typing.TypedDict):
+    value: list[int]
+    padding: list[int]
+
+
+@dataclass
+class BigFractionBytes:
+    layout: typing.ClassVar = borsh.CStruct(
+        "value" / borsh.U64[4], "padding" / borsh.U64[2]
+    )
+    value: list[int]
+    padding: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "BigFractionBytes":
+        return cls(value=obj.value, padding=obj.padding)
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {"value": self.value, "padding": self.padding}
+
+    def to_json(self) -> BigFractionBytesJSON:
+        return {"value": self.value, "padding": self.padding}
+
+    @classmethod
+    def from_json(cls, obj: BigFractionBytesJSON) -> "BigFractionBytes":
+        return cls(value=obj["value"], padding=obj["padding"])

--- a/codegen_lend/types/borrow_rate_curve.py
+++ b/codegen_lend/types/borrow_rate_curve.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+from . import (
+    curve_point,
+)
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class BorrowRateCurveJSON(typing.TypedDict):
+    points: list[curve_point.CurvePointJSON]
+
+
+@dataclass
+class BorrowRateCurve:
+    layout: typing.ClassVar = borsh.CStruct(
+        "points" / curve_point.CurvePoint.layout[11]
+    )
+    points: list[curve_point.CurvePoint]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "BorrowRateCurve":
+        return cls(
+            points=list(
+                map(lambda item: curve_point.CurvePoint.from_decoded(item), obj.points)
+            )
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {"points": list(map(lambda item: item.to_encodable(), self.points))}
+
+    def to_json(self) -> BorrowRateCurveJSON:
+        return {"points": list(map(lambda item: item.to_json(), self.points))}
+
+    @classmethod
+    def from_json(cls, obj: BorrowRateCurveJSON) -> "BorrowRateCurve":
+        return cls(
+            points=list(
+                map(lambda item: curve_point.CurvePoint.from_json(item), obj["points"])
+            )
+        )

--- a/codegen_lend/types/curve_point.py
+++ b/codegen_lend/types/curve_point.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class CurvePointJSON(typing.TypedDict):
+    utilization_rate_bps: int
+    borrow_rate_bps: int
+
+
+@dataclass
+class CurvePoint:
+    layout: typing.ClassVar = borsh.CStruct(
+        "utilization_rate_bps" / borsh.U32, "borrow_rate_bps" / borsh.U32
+    )
+    utilization_rate_bps: int
+    borrow_rate_bps: int
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "CurvePoint":
+        return cls(
+            utilization_rate_bps=obj.utilization_rate_bps,
+            borrow_rate_bps=obj.borrow_rate_bps,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "utilization_rate_bps": self.utilization_rate_bps,
+            "borrow_rate_bps": self.borrow_rate_bps,
+        }
+
+    def to_json(self) -> CurvePointJSON:
+        return {
+            "utilization_rate_bps": self.utilization_rate_bps,
+            "borrow_rate_bps": self.borrow_rate_bps,
+        }
+
+    @classmethod
+    def from_json(cls, obj: CurvePointJSON) -> "CurvePoint":
+        return cls(
+            utilization_rate_bps=obj["utilization_rate_bps"],
+            borrow_rate_bps=obj["borrow_rate_bps"],
+        )

--- a/codegen_lend/types/elevation_group.py
+++ b/codegen_lend/types/elevation_group.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class ElevationGroupJSON(typing.TypedDict):
+    max_liquidation_bonus_bps: int
+    id: int
+    ltv_pct: int
+    liquidation_threshold_pct: int
+    allow_new_loans: int
+    max_reserves_as_collateral: int
+    padding0: int
+    debt_reserve: str
+    padding1: list[int]
+
+
+@dataclass
+class ElevationGroup:
+    layout: typing.ClassVar = borsh.CStruct(
+        "max_liquidation_bonus_bps" / borsh.U16,
+        "id" / borsh.U8,
+        "ltv_pct" / borsh.U8,
+        "liquidation_threshold_pct" / borsh.U8,
+        "allow_new_loans" / borsh.U8,
+        "max_reserves_as_collateral" / borsh.U8,
+        "padding0" / borsh.U8,
+        "debt_reserve" / BorshPubkey,
+        "padding1" / borsh.U64[4],
+    )
+    max_liquidation_bonus_bps: int
+    id: int
+    ltv_pct: int
+    liquidation_threshold_pct: int
+    allow_new_loans: int
+    max_reserves_as_collateral: int
+    padding0: int
+    debt_reserve: Pubkey
+    padding1: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ElevationGroup":
+        return cls(
+            max_liquidation_bonus_bps=obj.max_liquidation_bonus_bps,
+            id=obj.id,
+            ltv_pct=obj.ltv_pct,
+            liquidation_threshold_pct=obj.liquidation_threshold_pct,
+            allow_new_loans=obj.allow_new_loans,
+            max_reserves_as_collateral=obj.max_reserves_as_collateral,
+            padding0=obj.padding0,
+            debt_reserve=obj.debt_reserve,
+            padding1=obj.padding1,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "max_liquidation_bonus_bps": self.max_liquidation_bonus_bps,
+            "id": self.id,
+            "ltv_pct": self.ltv_pct,
+            "liquidation_threshold_pct": self.liquidation_threshold_pct,
+            "allow_new_loans": self.allow_new_loans,
+            "max_reserves_as_collateral": self.max_reserves_as_collateral,
+            "padding0": self.padding0,
+            "debt_reserve": self.debt_reserve,
+            "padding1": self.padding1,
+        }
+
+    def to_json(self) -> ElevationGroupJSON:
+        return {
+            "max_liquidation_bonus_bps": self.max_liquidation_bonus_bps,
+            "id": self.id,
+            "ltv_pct": self.ltv_pct,
+            "liquidation_threshold_pct": self.liquidation_threshold_pct,
+            "allow_new_loans": self.allow_new_loans,
+            "max_reserves_as_collateral": self.max_reserves_as_collateral,
+            "padding0": self.padding0,
+            "debt_reserve": str(self.debt_reserve),
+            "padding1": self.padding1,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ElevationGroupJSON) -> "ElevationGroup":
+        return cls(
+            max_liquidation_bonus_bps=obj["max_liquidation_bonus_bps"],
+            id=obj["id"],
+            ltv_pct=obj["ltv_pct"],
+            liquidation_threshold_pct=obj["liquidation_threshold_pct"],
+            allow_new_loans=obj["allow_new_loans"],
+            max_reserves_as_collateral=obj["max_reserves_as_collateral"],
+            padding0=obj["padding0"],
+            debt_reserve=Pubkey.from_string(obj["debt_reserve"]),
+            padding1=obj["padding1"],
+        )

--- a/codegen_lend/types/fee_calculation.py
+++ b/codegen_lend/types/fee_calculation.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
+
+
+class ExclusiveJSON(typing.TypedDict):
+    kind: typing.Literal["Exclusive"]
+
+
+class InclusiveJSON(typing.TypedDict):
+    kind: typing.Literal["Inclusive"]
+
+
+@dataclass
+class Exclusive:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "Exclusive"
+
+    @classmethod
+    def to_json(cls) -> ExclusiveJSON:
+        return ExclusiveJSON(
+            kind="Exclusive",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Exclusive": {},
+        }
+
+
+@dataclass
+class Inclusive:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "Inclusive"
+
+    @classmethod
+    def to_json(cls) -> InclusiveJSON:
+        return InclusiveJSON(
+            kind="Inclusive",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Inclusive": {},
+        }
+
+
+FeeCalculationKind = typing.Union[Exclusive, Inclusive]
+FeeCalculationJSON = typing.Union[ExclusiveJSON, InclusiveJSON]
+
+
+def from_decoded(obj: dict) -> FeeCalculationKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "Exclusive" in obj:
+        return Exclusive()
+    if "Inclusive" in obj:
+        return Inclusive()
+    raise ValueError("Invalid enum object")
+
+
+def from_json(obj: FeeCalculationJSON) -> FeeCalculationKind:
+    if obj["kind"] == "Exclusive":
+        return Exclusive()
+    if obj["kind"] == "Inclusive":
+        return Inclusive()
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen("Exclusive" / borsh.CStruct(), "Inclusive" / borsh.CStruct())

--- a/codegen_lend/types/init_obligation_args.py
+++ b/codegen_lend/types/init_obligation_args.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class InitObligationArgsJSON(typing.TypedDict):
+    tag: int
+    id: int
+
+
+@dataclass
+class InitObligationArgs:
+    layout: typing.ClassVar = borsh.CStruct("tag" / borsh.U8, "id" / borsh.U8)
+    tag: int
+    id: int
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "InitObligationArgs":
+        return cls(tag=obj.tag, id=obj.id)
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {"tag": self.tag, "id": self.id}
+
+    def to_json(self) -> InitObligationArgsJSON:
+        return {"tag": self.tag, "id": self.id}
+
+    @classmethod
+    def from_json(cls, obj: InitObligationArgsJSON) -> "InitObligationArgs":
+        return cls(tag=obj["tag"], id=obj["id"])

--- a/codegen_lend/types/last_update.py
+++ b/codegen_lend/types/last_update.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class LastUpdateJSON(typing.TypedDict):
+    slot: int
+    stale: int
+    price_status: int
+    placeholder: list[int]
+
+
+@dataclass
+class LastUpdate:
+    layout: typing.ClassVar = borsh.CStruct(
+        "slot" / borsh.U64,
+        "stale" / borsh.U8,
+        "price_status" / borsh.U8,
+        "placeholder" / borsh.U8[6],
+    )
+    slot: int
+    stale: int
+    price_status: int
+    placeholder: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "LastUpdate":
+        return cls(
+            slot=obj.slot,
+            stale=obj.stale,
+            price_status=obj.price_status,
+            placeholder=obj.placeholder,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "slot": self.slot,
+            "stale": self.stale,
+            "price_status": self.price_status,
+            "placeholder": self.placeholder,
+        }
+
+    def to_json(self) -> LastUpdateJSON:
+        return {
+            "slot": self.slot,
+            "stale": self.stale,
+            "price_status": self.price_status,
+            "placeholder": self.placeholder,
+        }
+
+    @classmethod
+    def from_json(cls, obj: LastUpdateJSON) -> "LastUpdate":
+        return cls(
+            slot=obj["slot"],
+            stale=obj["stale"],
+            price_status=obj["price_status"],
+            placeholder=obj["placeholder"],
+        )

--- a/codegen_lend/types/obligation_collateral.py
+++ b/codegen_lend/types/obligation_collateral.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class ObligationCollateralJSON(typing.TypedDict):
+    deposit_reserve: str
+    deposited_amount: int
+    market_value_sf: int
+    borrowed_amount_against_this_collateral_in_elevation_group: int
+    padding: list[int]
+
+
+@dataclass
+class ObligationCollateral:
+    layout: typing.ClassVar = borsh.CStruct(
+        "deposit_reserve" / BorshPubkey,
+        "deposited_amount" / borsh.U64,
+        "market_value_sf" / borsh.U128,
+        "borrowed_amount_against_this_collateral_in_elevation_group" / borsh.U64,
+        "padding" / borsh.U64[9],
+    )
+    deposit_reserve: Pubkey
+    deposited_amount: int
+    market_value_sf: int
+    borrowed_amount_against_this_collateral_in_elevation_group: int
+    padding: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ObligationCollateral":
+        return cls(
+            deposit_reserve=obj.deposit_reserve,
+            deposited_amount=obj.deposited_amount,
+            market_value_sf=obj.market_value_sf,
+            borrowed_amount_against_this_collateral_in_elevation_group=obj.borrowed_amount_against_this_collateral_in_elevation_group,
+            padding=obj.padding,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "deposit_reserve": self.deposit_reserve,
+            "deposited_amount": self.deposited_amount,
+            "market_value_sf": self.market_value_sf,
+            "borrowed_amount_against_this_collateral_in_elevation_group": self.borrowed_amount_against_this_collateral_in_elevation_group,
+            "padding": self.padding,
+        }
+
+    def to_json(self) -> ObligationCollateralJSON:
+        return {
+            "deposit_reserve": str(self.deposit_reserve),
+            "deposited_amount": self.deposited_amount,
+            "market_value_sf": self.market_value_sf,
+            "borrowed_amount_against_this_collateral_in_elevation_group": self.borrowed_amount_against_this_collateral_in_elevation_group,
+            "padding": self.padding,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ObligationCollateralJSON) -> "ObligationCollateral":
+        return cls(
+            deposit_reserve=Pubkey.from_string(obj["deposit_reserve"]),
+            deposited_amount=obj["deposited_amount"],
+            market_value_sf=obj["market_value_sf"],
+            borrowed_amount_against_this_collateral_in_elevation_group=obj[
+                "borrowed_amount_against_this_collateral_in_elevation_group"
+            ],
+            padding=obj["padding"],
+        )

--- a/codegen_lend/types/obligation_liquidity.py
+++ b/codegen_lend/types/obligation_liquidity.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+from . import (
+    big_fraction_bytes,
+)
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class ObligationLiquidityJSON(typing.TypedDict):
+    borrow_reserve: str
+    cumulative_borrow_rate_bsf: big_fraction_bytes.BigFractionBytesJSON
+    padding: int
+    borrowed_amount_sf: int
+    market_value_sf: int
+    borrow_factor_adjusted_market_value_sf: int
+    borrowed_amount_outside_elevation_groups: int
+    padding2: list[int]
+
+
+@dataclass
+class ObligationLiquidity:
+    layout: typing.ClassVar = borsh.CStruct(
+        "borrow_reserve" / BorshPubkey,
+        "cumulative_borrow_rate_bsf" / big_fraction_bytes.BigFractionBytes.layout,
+        "padding" / borsh.U64,
+        "borrowed_amount_sf" / borsh.U128,
+        "market_value_sf" / borsh.U128,
+        "borrow_factor_adjusted_market_value_sf" / borsh.U128,
+        "borrowed_amount_outside_elevation_groups" / borsh.U64,
+        "padding2" / borsh.U64[7],
+    )
+    borrow_reserve: Pubkey
+    cumulative_borrow_rate_bsf: big_fraction_bytes.BigFractionBytes
+    padding: int
+    borrowed_amount_sf: int
+    market_value_sf: int
+    borrow_factor_adjusted_market_value_sf: int
+    borrowed_amount_outside_elevation_groups: int
+    padding2: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ObligationLiquidity":
+        return cls(
+            borrow_reserve=obj.borrow_reserve,
+            cumulative_borrow_rate_bsf=big_fraction_bytes.BigFractionBytes.from_decoded(
+                obj.cumulative_borrow_rate_bsf
+            ),
+            padding=obj.padding,
+            borrowed_amount_sf=obj.borrowed_amount_sf,
+            market_value_sf=obj.market_value_sf,
+            borrow_factor_adjusted_market_value_sf=obj.borrow_factor_adjusted_market_value_sf,
+            borrowed_amount_outside_elevation_groups=obj.borrowed_amount_outside_elevation_groups,
+            padding2=obj.padding2,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "borrow_reserve": self.borrow_reserve,
+            "cumulative_borrow_rate_bsf": self.cumulative_borrow_rate_bsf.to_encodable(),
+            "padding": self.padding,
+            "borrowed_amount_sf": self.borrowed_amount_sf,
+            "market_value_sf": self.market_value_sf,
+            "borrow_factor_adjusted_market_value_sf": self.borrow_factor_adjusted_market_value_sf,
+            "borrowed_amount_outside_elevation_groups": self.borrowed_amount_outside_elevation_groups,
+            "padding2": self.padding2,
+        }
+
+    def to_json(self) -> ObligationLiquidityJSON:
+        return {
+            "borrow_reserve": str(self.borrow_reserve),
+            "cumulative_borrow_rate_bsf": self.cumulative_borrow_rate_bsf.to_json(),
+            "padding": self.padding,
+            "borrowed_amount_sf": self.borrowed_amount_sf,
+            "market_value_sf": self.market_value_sf,
+            "borrow_factor_adjusted_market_value_sf": self.borrow_factor_adjusted_market_value_sf,
+            "borrowed_amount_outside_elevation_groups": self.borrowed_amount_outside_elevation_groups,
+            "padding2": self.padding2,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ObligationLiquidityJSON) -> "ObligationLiquidity":
+        return cls(
+            borrow_reserve=Pubkey.from_string(obj["borrow_reserve"]),
+            cumulative_borrow_rate_bsf=big_fraction_bytes.BigFractionBytes.from_json(
+                obj["cumulative_borrow_rate_bsf"]
+            ),
+            padding=obj["padding"],
+            borrowed_amount_sf=obj["borrowed_amount_sf"],
+            market_value_sf=obj["market_value_sf"],
+            borrow_factor_adjusted_market_value_sf=obj[
+                "borrow_factor_adjusted_market_value_sf"
+            ],
+            borrowed_amount_outside_elevation_groups=obj[
+                "borrowed_amount_outside_elevation_groups"
+            ],
+            padding2=obj["padding2"],
+        )

--- a/codegen_lend/types/price_heuristic.py
+++ b/codegen_lend/types/price_heuristic.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class PriceHeuristicJSON(typing.TypedDict):
+    lower: int
+    upper: int
+    exp: int
+
+
+@dataclass
+class PriceHeuristic:
+    layout: typing.ClassVar = borsh.CStruct(
+        "lower" / borsh.U64, "upper" / borsh.U64, "exp" / borsh.U64
+    )
+    lower: int
+    upper: int
+    exp: int
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "PriceHeuristic":
+        return cls(lower=obj.lower, upper=obj.upper, exp=obj.exp)
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {"lower": self.lower, "upper": self.upper, "exp": self.exp}
+
+    def to_json(self) -> PriceHeuristicJSON:
+        return {"lower": self.lower, "upper": self.upper, "exp": self.exp}
+
+    @classmethod
+    def from_json(cls, obj: PriceHeuristicJSON) -> "PriceHeuristic":
+        return cls(lower=obj["lower"], upper=obj["upper"], exp=obj["exp"])

--- a/codegen_lend/types/pyth_configuration.py
+++ b/codegen_lend/types/pyth_configuration.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class PythConfigurationJSON(typing.TypedDict):
+    price: str
+
+
+@dataclass
+class PythConfiguration:
+    layout: typing.ClassVar = borsh.CStruct("price" / BorshPubkey)
+    price: Pubkey
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "PythConfiguration":
+        return cls(price=obj.price)
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {"price": self.price}
+
+    def to_json(self) -> PythConfigurationJSON:
+        return {"price": str(self.price)}
+
+    @classmethod
+    def from_json(cls, obj: PythConfigurationJSON) -> "PythConfiguration":
+        return cls(price=Pubkey.from_string(obj["price"]))

--- a/codegen_lend/types/reserve_collateral.py
+++ b/codegen_lend/types/reserve_collateral.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class ReserveCollateralJSON(typing.TypedDict):
+    mint_pubkey: str
+    mint_total_supply: int
+    supply_vault: str
+    padding1: list[int]
+    padding2: list[int]
+
+
+@dataclass
+class ReserveCollateral:
+    layout: typing.ClassVar = borsh.CStruct(
+        "mint_pubkey" / BorshPubkey,
+        "mint_total_supply" / borsh.U64,
+        "supply_vault" / BorshPubkey,
+        "padding1" / borsh.U128[32],
+        "padding2" / borsh.U128[32],
+    )
+    mint_pubkey: Pubkey
+    mint_total_supply: int
+    supply_vault: Pubkey
+    padding1: list[int]
+    padding2: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ReserveCollateral":
+        return cls(
+            mint_pubkey=obj.mint_pubkey,
+            mint_total_supply=obj.mint_total_supply,
+            supply_vault=obj.supply_vault,
+            padding1=obj.padding1,
+            padding2=obj.padding2,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "mint_pubkey": self.mint_pubkey,
+            "mint_total_supply": self.mint_total_supply,
+            "supply_vault": self.supply_vault,
+            "padding1": self.padding1,
+            "padding2": self.padding2,
+        }
+
+    def to_json(self) -> ReserveCollateralJSON:
+        return {
+            "mint_pubkey": str(self.mint_pubkey),
+            "mint_total_supply": self.mint_total_supply,
+            "supply_vault": str(self.supply_vault),
+            "padding1": self.padding1,
+            "padding2": self.padding2,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ReserveCollateralJSON) -> "ReserveCollateral":
+        return cls(
+            mint_pubkey=Pubkey.from_string(obj["mint_pubkey"]),
+            mint_total_supply=obj["mint_total_supply"],
+            supply_vault=Pubkey.from_string(obj["supply_vault"]),
+            padding1=obj["padding1"],
+            padding2=obj["padding2"],
+        )

--- a/codegen_lend/types/reserve_config.py
+++ b/codegen_lend/types/reserve_config.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+from . import (
+    reserve_fees,
+    withdrawal_caps,
+    token_info,
+    borrow_rate_curve,
+)
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class ReserveConfigJSON(typing.TypedDict):
+    status: int
+    asset_tier: int
+    host_fixed_interest_rate_bps: int
+    multiplier_side_boost: list[int]
+    multiplier_tag_boost: list[int]
+    protocol_take_rate_pct: int
+    protocol_liquidation_fee_pct: int
+    loan_to_value_pct: int
+    liquidation_threshold_pct: int
+    min_liquidation_bonus_bps: int
+    max_liquidation_bonus_bps: int
+    bad_debt_liquidation_bonus_bps: int
+    deleveraging_margin_call_period_secs: int
+    deleveraging_threshold_slots_per_bps: int
+    fees: reserve_fees.ReserveFeesJSON
+    borrow_rate_curve: borrow_rate_curve.BorrowRateCurveJSON
+    borrow_factor_pct: int
+    deposit_limit: int
+    borrow_limit: int
+    token_info: token_info.TokenInfoJSON
+    deposit_withdrawal_cap: withdrawal_caps.WithdrawalCapsJSON
+    debt_withdrawal_cap: withdrawal_caps.WithdrawalCapsJSON
+    elevation_groups: list[int]
+    disable_usage_as_coll_outside_emode: int
+    utilization_limit_block_borrowing_above: int
+    reserved1: list[int]
+    borrow_limit_outside_elevation_group: int
+    borrow_limit_against_this_collateral_in_elevation_group: list[int]
+
+
+@dataclass
+class ReserveConfig:
+    layout: typing.ClassVar = borsh.CStruct(
+        "status" / borsh.U8,
+        "asset_tier" / borsh.U8,
+        "host_fixed_interest_rate_bps" / borsh.U16,
+        "multiplier_side_boost" / borsh.U8[2],
+        "multiplier_tag_boost" / borsh.U8[8],
+        "protocol_take_rate_pct" / borsh.U8,
+        "protocol_liquidation_fee_pct" / borsh.U8,
+        "loan_to_value_pct" / borsh.U8,
+        "liquidation_threshold_pct" / borsh.U8,
+        "min_liquidation_bonus_bps" / borsh.U16,
+        "max_liquidation_bonus_bps" / borsh.U16,
+        "bad_debt_liquidation_bonus_bps" / borsh.U16,
+        "deleveraging_margin_call_period_secs" / borsh.U64,
+        "deleveraging_threshold_slots_per_bps" / borsh.U64,
+        "fees" / reserve_fees.ReserveFees.layout,
+        "borrow_rate_curve" / borrow_rate_curve.BorrowRateCurve.layout,
+        "borrow_factor_pct" / borsh.U64,
+        "deposit_limit" / borsh.U64,
+        "borrow_limit" / borsh.U64,
+        "token_info" / token_info.TokenInfo.layout,
+        "deposit_withdrawal_cap" / withdrawal_caps.WithdrawalCaps.layout,
+        "debt_withdrawal_cap" / withdrawal_caps.WithdrawalCaps.layout,
+        "elevation_groups" / borsh.U8[20],
+        "disable_usage_as_coll_outside_emode" / borsh.U8,
+        "utilization_limit_block_borrowing_above" / borsh.U8,
+        "reserved1" / borsh.U8[2],
+        "borrow_limit_outside_elevation_group" / borsh.U64,
+        "borrow_limit_against_this_collateral_in_elevation_group" / borsh.U64[32],
+    )
+    status: int
+    asset_tier: int
+    host_fixed_interest_rate_bps: int
+    multiplier_side_boost: list[int]
+    multiplier_tag_boost: list[int]
+    protocol_take_rate_pct: int
+    protocol_liquidation_fee_pct: int
+    loan_to_value_pct: int
+    liquidation_threshold_pct: int
+    min_liquidation_bonus_bps: int
+    max_liquidation_bonus_bps: int
+    bad_debt_liquidation_bonus_bps: int
+    deleveraging_margin_call_period_secs: int
+    deleveraging_threshold_slots_per_bps: int
+    fees: reserve_fees.ReserveFees
+    borrow_rate_curve: borrow_rate_curve.BorrowRateCurve
+    borrow_factor_pct: int
+    deposit_limit: int
+    borrow_limit: int
+    token_info: token_info.TokenInfo
+    deposit_withdrawal_cap: withdrawal_caps.WithdrawalCaps
+    debt_withdrawal_cap: withdrawal_caps.WithdrawalCaps
+    elevation_groups: list[int]
+    disable_usage_as_coll_outside_emode: int
+    utilization_limit_block_borrowing_above: int
+    reserved1: list[int]
+    borrow_limit_outside_elevation_group: int
+    borrow_limit_against_this_collateral_in_elevation_group: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ReserveConfig":
+        return cls(
+            status=obj.status,
+            asset_tier=obj.asset_tier,
+            host_fixed_interest_rate_bps=obj.host_fixed_interest_rate_bps,
+            multiplier_side_boost=obj.multiplier_side_boost,
+            multiplier_tag_boost=obj.multiplier_tag_boost,
+            protocol_take_rate_pct=obj.protocol_take_rate_pct,
+            protocol_liquidation_fee_pct=obj.protocol_liquidation_fee_pct,
+            loan_to_value_pct=obj.loan_to_value_pct,
+            liquidation_threshold_pct=obj.liquidation_threshold_pct,
+            min_liquidation_bonus_bps=obj.min_liquidation_bonus_bps,
+            max_liquidation_bonus_bps=obj.max_liquidation_bonus_bps,
+            bad_debt_liquidation_bonus_bps=obj.bad_debt_liquidation_bonus_bps,
+            deleveraging_margin_call_period_secs=obj.deleveraging_margin_call_period_secs,
+            deleveraging_threshold_slots_per_bps=obj.deleveraging_threshold_slots_per_bps,
+            fees=reserve_fees.ReserveFees.from_decoded(obj.fees),
+            borrow_rate_curve=borrow_rate_curve.BorrowRateCurve.from_decoded(
+                obj.borrow_rate_curve
+            ),
+            borrow_factor_pct=obj.borrow_factor_pct,
+            deposit_limit=obj.deposit_limit,
+            borrow_limit=obj.borrow_limit,
+            token_info=token_info.TokenInfo.from_decoded(obj.token_info),
+            deposit_withdrawal_cap=withdrawal_caps.WithdrawalCaps.from_decoded(
+                obj.deposit_withdrawal_cap
+            ),
+            debt_withdrawal_cap=withdrawal_caps.WithdrawalCaps.from_decoded(
+                obj.debt_withdrawal_cap
+            ),
+            elevation_groups=obj.elevation_groups,
+            disable_usage_as_coll_outside_emode=obj.disable_usage_as_coll_outside_emode,
+            utilization_limit_block_borrowing_above=obj.utilization_limit_block_borrowing_above,
+            reserved1=obj.reserved1,
+            borrow_limit_outside_elevation_group=obj.borrow_limit_outside_elevation_group,
+            borrow_limit_against_this_collateral_in_elevation_group=obj.borrow_limit_against_this_collateral_in_elevation_group,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "status": self.status,
+            "asset_tier": self.asset_tier,
+            "host_fixed_interest_rate_bps": self.host_fixed_interest_rate_bps,
+            "multiplier_side_boost": self.multiplier_side_boost,
+            "multiplier_tag_boost": self.multiplier_tag_boost,
+            "protocol_take_rate_pct": self.protocol_take_rate_pct,
+            "protocol_liquidation_fee_pct": self.protocol_liquidation_fee_pct,
+            "loan_to_value_pct": self.loan_to_value_pct,
+            "liquidation_threshold_pct": self.liquidation_threshold_pct,
+            "min_liquidation_bonus_bps": self.min_liquidation_bonus_bps,
+            "max_liquidation_bonus_bps": self.max_liquidation_bonus_bps,
+            "bad_debt_liquidation_bonus_bps": self.bad_debt_liquidation_bonus_bps,
+            "deleveraging_margin_call_period_secs": self.deleveraging_margin_call_period_secs,
+            "deleveraging_threshold_slots_per_bps": self.deleveraging_threshold_slots_per_bps,
+            "fees": self.fees.to_encodable(),
+            "borrow_rate_curve": self.borrow_rate_curve.to_encodable(),
+            "borrow_factor_pct": self.borrow_factor_pct,
+            "deposit_limit": self.deposit_limit,
+            "borrow_limit": self.borrow_limit,
+            "token_info": self.token_info.to_encodable(),
+            "deposit_withdrawal_cap": self.deposit_withdrawal_cap.to_encodable(),
+            "debt_withdrawal_cap": self.debt_withdrawal_cap.to_encodable(),
+            "elevation_groups": self.elevation_groups,
+            "disable_usage_as_coll_outside_emode": self.disable_usage_as_coll_outside_emode,
+            "utilization_limit_block_borrowing_above": self.utilization_limit_block_borrowing_above,
+            "reserved1": self.reserved1,
+            "borrow_limit_outside_elevation_group": self.borrow_limit_outside_elevation_group,
+            "borrow_limit_against_this_collateral_in_elevation_group": self.borrow_limit_against_this_collateral_in_elevation_group,
+        }
+
+    def to_json(self) -> ReserveConfigJSON:
+        return {
+            "status": self.status,
+            "asset_tier": self.asset_tier,
+            "host_fixed_interest_rate_bps": self.host_fixed_interest_rate_bps,
+            "multiplier_side_boost": self.multiplier_side_boost,
+            "multiplier_tag_boost": self.multiplier_tag_boost,
+            "protocol_take_rate_pct": self.protocol_take_rate_pct,
+            "protocol_liquidation_fee_pct": self.protocol_liquidation_fee_pct,
+            "loan_to_value_pct": self.loan_to_value_pct,
+            "liquidation_threshold_pct": self.liquidation_threshold_pct,
+            "min_liquidation_bonus_bps": self.min_liquidation_bonus_bps,
+            "max_liquidation_bonus_bps": self.max_liquidation_bonus_bps,
+            "bad_debt_liquidation_bonus_bps": self.bad_debt_liquidation_bonus_bps,
+            "deleveraging_margin_call_period_secs": self.deleveraging_margin_call_period_secs,
+            "deleveraging_threshold_slots_per_bps": self.deleveraging_threshold_slots_per_bps,
+            "fees": self.fees.to_json(),
+            "borrow_rate_curve": self.borrow_rate_curve.to_json(),
+            "borrow_factor_pct": self.borrow_factor_pct,
+            "deposit_limit": self.deposit_limit,
+            "borrow_limit": self.borrow_limit,
+            "token_info": self.token_info.to_json(),
+            "deposit_withdrawal_cap": self.deposit_withdrawal_cap.to_json(),
+            "debt_withdrawal_cap": self.debt_withdrawal_cap.to_json(),
+            "elevation_groups": self.elevation_groups,
+            "disable_usage_as_coll_outside_emode": self.disable_usage_as_coll_outside_emode,
+            "utilization_limit_block_borrowing_above": self.utilization_limit_block_borrowing_above,
+            "reserved1": self.reserved1,
+            "borrow_limit_outside_elevation_group": self.borrow_limit_outside_elevation_group,
+            "borrow_limit_against_this_collateral_in_elevation_group": self.borrow_limit_against_this_collateral_in_elevation_group,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ReserveConfigJSON) -> "ReserveConfig":
+        return cls(
+            status=obj["status"],
+            asset_tier=obj["asset_tier"],
+            host_fixed_interest_rate_bps=obj["host_fixed_interest_rate_bps"],
+            multiplier_side_boost=obj["multiplier_side_boost"],
+            multiplier_tag_boost=obj["multiplier_tag_boost"],
+            protocol_take_rate_pct=obj["protocol_take_rate_pct"],
+            protocol_liquidation_fee_pct=obj["protocol_liquidation_fee_pct"],
+            loan_to_value_pct=obj["loan_to_value_pct"],
+            liquidation_threshold_pct=obj["liquidation_threshold_pct"],
+            min_liquidation_bonus_bps=obj["min_liquidation_bonus_bps"],
+            max_liquidation_bonus_bps=obj["max_liquidation_bonus_bps"],
+            bad_debt_liquidation_bonus_bps=obj["bad_debt_liquidation_bonus_bps"],
+            deleveraging_margin_call_period_secs=obj[
+                "deleveraging_margin_call_period_secs"
+            ],
+            deleveraging_threshold_slots_per_bps=obj[
+                "deleveraging_threshold_slots_per_bps"
+            ],
+            fees=reserve_fees.ReserveFees.from_json(obj["fees"]),
+            borrow_rate_curve=borrow_rate_curve.BorrowRateCurve.from_json(
+                obj["borrow_rate_curve"]
+            ),
+            borrow_factor_pct=obj["borrow_factor_pct"],
+            deposit_limit=obj["deposit_limit"],
+            borrow_limit=obj["borrow_limit"],
+            token_info=token_info.TokenInfo.from_json(obj["token_info"]),
+            deposit_withdrawal_cap=withdrawal_caps.WithdrawalCaps.from_json(
+                obj["deposit_withdrawal_cap"]
+            ),
+            debt_withdrawal_cap=withdrawal_caps.WithdrawalCaps.from_json(
+                obj["debt_withdrawal_cap"]
+            ),
+            elevation_groups=obj["elevation_groups"],
+            disable_usage_as_coll_outside_emode=obj[
+                "disable_usage_as_coll_outside_emode"
+            ],
+            utilization_limit_block_borrowing_above=obj[
+                "utilization_limit_block_borrowing_above"
+            ],
+            reserved1=obj["reserved1"],
+            borrow_limit_outside_elevation_group=obj[
+                "borrow_limit_outside_elevation_group"
+            ],
+            borrow_limit_against_this_collateral_in_elevation_group=obj[
+                "borrow_limit_against_this_collateral_in_elevation_group"
+            ],
+        )

--- a/codegen_lend/types/reserve_farm_kind.py
+++ b/codegen_lend/types/reserve_farm_kind.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
+
+
+class CollateralJSON(typing.TypedDict):
+    kind: typing.Literal["Collateral"]
+
+
+class DebtJSON(typing.TypedDict):
+    kind: typing.Literal["Debt"]
+
+
+@dataclass
+class Collateral:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "Collateral"
+
+    @classmethod
+    def to_json(cls) -> CollateralJSON:
+        return CollateralJSON(
+            kind="Collateral",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Collateral": {},
+        }
+
+
+@dataclass
+class Debt:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "Debt"
+
+    @classmethod
+    def to_json(cls) -> DebtJSON:
+        return DebtJSON(
+            kind="Debt",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Debt": {},
+        }
+
+
+ReserveFarmKindKind = typing.Union[Collateral, Debt]
+ReserveFarmKindJSON = typing.Union[CollateralJSON, DebtJSON]
+
+
+def from_decoded(obj: dict) -> ReserveFarmKindKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "Collateral" in obj:
+        return Collateral()
+    if "Debt" in obj:
+        return Debt()
+    raise ValueError("Invalid enum object")
+
+
+def from_json(obj: ReserveFarmKindJSON) -> ReserveFarmKindKind:
+    if obj["kind"] == "Collateral":
+        return Collateral()
+    if obj["kind"] == "Debt":
+        return Debt()
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen("Collateral" / borsh.CStruct(), "Debt" / borsh.CStruct())

--- a/codegen_lend/types/reserve_fees.py
+++ b/codegen_lend/types/reserve_fees.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class ReserveFeesJSON(typing.TypedDict):
+    borrow_fee_sf: int
+    flash_loan_fee_sf: int
+    padding: list[int]
+
+
+@dataclass
+class ReserveFees:
+    layout: typing.ClassVar = borsh.CStruct(
+        "borrow_fee_sf" / borsh.U64,
+        "flash_loan_fee_sf" / borsh.U64,
+        "padding" / borsh.U8[8],
+    )
+    borrow_fee_sf: int
+    flash_loan_fee_sf: int
+    padding: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ReserveFees":
+        return cls(
+            borrow_fee_sf=obj.borrow_fee_sf,
+            flash_loan_fee_sf=obj.flash_loan_fee_sf,
+            padding=obj.padding,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "borrow_fee_sf": self.borrow_fee_sf,
+            "flash_loan_fee_sf": self.flash_loan_fee_sf,
+            "padding": self.padding,
+        }
+
+    def to_json(self) -> ReserveFeesJSON:
+        return {
+            "borrow_fee_sf": self.borrow_fee_sf,
+            "flash_loan_fee_sf": self.flash_loan_fee_sf,
+            "padding": self.padding,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ReserveFeesJSON) -> "ReserveFees":
+        return cls(
+            borrow_fee_sf=obj["borrow_fee_sf"],
+            flash_loan_fee_sf=obj["flash_loan_fee_sf"],
+            padding=obj["padding"],
+        )

--- a/codegen_lend/types/reserve_liquidity.py
+++ b/codegen_lend/types/reserve_liquidity.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+from . import (
+    big_fraction_bytes,
+)
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class ReserveLiquidityJSON(typing.TypedDict):
+    mint_pubkey: str
+    supply_vault: str
+    fee_vault: str
+    available_amount: int
+    borrowed_amount_sf: int
+    market_price_sf: int
+    market_price_last_updated_ts: int
+    mint_decimals: int
+    deposit_limit_crossed_slot: int
+    borrow_limit_crossed_slot: int
+    cumulative_borrow_rate_bsf: big_fraction_bytes.BigFractionBytesJSON
+    accumulated_protocol_fees_sf: int
+    accumulated_referrer_fees_sf: int
+    pending_referrer_fees_sf: int
+    absolute_referral_rate_sf: int
+    token_program: str
+    padding2: list[int]
+    padding3: list[int]
+
+
+@dataclass
+class ReserveLiquidity:
+    layout: typing.ClassVar = borsh.CStruct(
+        "mint_pubkey" / BorshPubkey,
+        "supply_vault" / BorshPubkey,
+        "fee_vault" / BorshPubkey,
+        "available_amount" / borsh.U64,
+        "borrowed_amount_sf" / borsh.U128,
+        "market_price_sf" / borsh.U128,
+        "market_price_last_updated_ts" / borsh.U64,
+        "mint_decimals" / borsh.U64,
+        "deposit_limit_crossed_slot" / borsh.U64,
+        "borrow_limit_crossed_slot" / borsh.U64,
+        "cumulative_borrow_rate_bsf" / big_fraction_bytes.BigFractionBytes.layout,
+        "accumulated_protocol_fees_sf" / borsh.U128,
+        "accumulated_referrer_fees_sf" / borsh.U128,
+        "pending_referrer_fees_sf" / borsh.U128,
+        "absolute_referral_rate_sf" / borsh.U128,
+        "token_program" / BorshPubkey,
+        "padding2" / borsh.U64[51],
+        "padding3" / borsh.U128[32],
+    )
+    mint_pubkey: Pubkey
+    supply_vault: Pubkey
+    fee_vault: Pubkey
+    available_amount: int
+    borrowed_amount_sf: int
+    market_price_sf: int
+    market_price_last_updated_ts: int
+    mint_decimals: int
+    deposit_limit_crossed_slot: int
+    borrow_limit_crossed_slot: int
+    cumulative_borrow_rate_bsf: big_fraction_bytes.BigFractionBytes
+    accumulated_protocol_fees_sf: int
+    accumulated_referrer_fees_sf: int
+    pending_referrer_fees_sf: int
+    absolute_referral_rate_sf: int
+    token_program: Pubkey
+    padding2: list[int]
+    padding3: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ReserveLiquidity":
+        return cls(
+            mint_pubkey=obj.mint_pubkey,
+            supply_vault=obj.supply_vault,
+            fee_vault=obj.fee_vault,
+            available_amount=obj.available_amount,
+            borrowed_amount_sf=obj.borrowed_amount_sf,
+            market_price_sf=obj.market_price_sf,
+            market_price_last_updated_ts=obj.market_price_last_updated_ts,
+            mint_decimals=obj.mint_decimals,
+            deposit_limit_crossed_slot=obj.deposit_limit_crossed_slot,
+            borrow_limit_crossed_slot=obj.borrow_limit_crossed_slot,
+            cumulative_borrow_rate_bsf=big_fraction_bytes.BigFractionBytes.from_decoded(
+                obj.cumulative_borrow_rate_bsf
+            ),
+            accumulated_protocol_fees_sf=obj.accumulated_protocol_fees_sf,
+            accumulated_referrer_fees_sf=obj.accumulated_referrer_fees_sf,
+            pending_referrer_fees_sf=obj.pending_referrer_fees_sf,
+            absolute_referral_rate_sf=obj.absolute_referral_rate_sf,
+            token_program=obj.token_program,
+            padding2=obj.padding2,
+            padding3=obj.padding3,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "mint_pubkey": self.mint_pubkey,
+            "supply_vault": self.supply_vault,
+            "fee_vault": self.fee_vault,
+            "available_amount": self.available_amount,
+            "borrowed_amount_sf": self.borrowed_amount_sf,
+            "market_price_sf": self.market_price_sf,
+            "market_price_last_updated_ts": self.market_price_last_updated_ts,
+            "mint_decimals": self.mint_decimals,
+            "deposit_limit_crossed_slot": self.deposit_limit_crossed_slot,
+            "borrow_limit_crossed_slot": self.borrow_limit_crossed_slot,
+            "cumulative_borrow_rate_bsf": self.cumulative_borrow_rate_bsf.to_encodable(),
+            "accumulated_protocol_fees_sf": self.accumulated_protocol_fees_sf,
+            "accumulated_referrer_fees_sf": self.accumulated_referrer_fees_sf,
+            "pending_referrer_fees_sf": self.pending_referrer_fees_sf,
+            "absolute_referral_rate_sf": self.absolute_referral_rate_sf,
+            "token_program": self.token_program,
+            "padding2": self.padding2,
+            "padding3": self.padding3,
+        }
+
+    def to_json(self) -> ReserveLiquidityJSON:
+        return {
+            "mint_pubkey": str(self.mint_pubkey),
+            "supply_vault": str(self.supply_vault),
+            "fee_vault": str(self.fee_vault),
+            "available_amount": self.available_amount,
+            "borrowed_amount_sf": self.borrowed_amount_sf,
+            "market_price_sf": self.market_price_sf,
+            "market_price_last_updated_ts": self.market_price_last_updated_ts,
+            "mint_decimals": self.mint_decimals,
+            "deposit_limit_crossed_slot": self.deposit_limit_crossed_slot,
+            "borrow_limit_crossed_slot": self.borrow_limit_crossed_slot,
+            "cumulative_borrow_rate_bsf": self.cumulative_borrow_rate_bsf.to_json(),
+            "accumulated_protocol_fees_sf": self.accumulated_protocol_fees_sf,
+            "accumulated_referrer_fees_sf": self.accumulated_referrer_fees_sf,
+            "pending_referrer_fees_sf": self.pending_referrer_fees_sf,
+            "absolute_referral_rate_sf": self.absolute_referral_rate_sf,
+            "token_program": str(self.token_program),
+            "padding2": self.padding2,
+            "padding3": self.padding3,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ReserveLiquidityJSON) -> "ReserveLiquidity":
+        return cls(
+            mint_pubkey=Pubkey.from_string(obj["mint_pubkey"]),
+            supply_vault=Pubkey.from_string(obj["supply_vault"]),
+            fee_vault=Pubkey.from_string(obj["fee_vault"]),
+            available_amount=obj["available_amount"],
+            borrowed_amount_sf=obj["borrowed_amount_sf"],
+            market_price_sf=obj["market_price_sf"],
+            market_price_last_updated_ts=obj["market_price_last_updated_ts"],
+            mint_decimals=obj["mint_decimals"],
+            deposit_limit_crossed_slot=obj["deposit_limit_crossed_slot"],
+            borrow_limit_crossed_slot=obj["borrow_limit_crossed_slot"],
+            cumulative_borrow_rate_bsf=big_fraction_bytes.BigFractionBytes.from_json(
+                obj["cumulative_borrow_rate_bsf"]
+            ),
+            accumulated_protocol_fees_sf=obj["accumulated_protocol_fees_sf"],
+            accumulated_referrer_fees_sf=obj["accumulated_referrer_fees_sf"],
+            pending_referrer_fees_sf=obj["pending_referrer_fees_sf"],
+            absolute_referral_rate_sf=obj["absolute_referral_rate_sf"],
+            token_program=Pubkey.from_string(obj["token_program"]),
+            padding2=obj["padding2"],
+            padding3=obj["padding3"],
+        )

--- a/codegen_lend/types/reserve_status.py
+++ b/codegen_lend/types/reserve_status.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
+
+
+class ActiveJSON(typing.TypedDict):
+    kind: typing.Literal["Active"]
+
+
+class ObsoleteJSON(typing.TypedDict):
+    kind: typing.Literal["Obsolete"]
+
+
+class HiddenJSON(typing.TypedDict):
+    kind: typing.Literal["Hidden"]
+
+
+@dataclass
+class Active:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "Active"
+
+    @classmethod
+    def to_json(cls) -> ActiveJSON:
+        return ActiveJSON(
+            kind="Active",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Active": {},
+        }
+
+
+@dataclass
+class Obsolete:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "Obsolete"
+
+    @classmethod
+    def to_json(cls) -> ObsoleteJSON:
+        return ObsoleteJSON(
+            kind="Obsolete",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Obsolete": {},
+        }
+
+
+@dataclass
+class Hidden:
+    discriminator: typing.ClassVar = 2
+    kind: typing.ClassVar = "Hidden"
+
+    @classmethod
+    def to_json(cls) -> HiddenJSON:
+        return HiddenJSON(
+            kind="Hidden",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "Hidden": {},
+        }
+
+
+ReserveStatusKind = typing.Union[Active, Obsolete, Hidden]
+ReserveStatusJSON = typing.Union[ActiveJSON, ObsoleteJSON, HiddenJSON]
+
+
+def from_decoded(obj: dict) -> ReserveStatusKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "Active" in obj:
+        return Active()
+    if "Obsolete" in obj:
+        return Obsolete()
+    if "Hidden" in obj:
+        return Hidden()
+    raise ValueError("Invalid enum object")
+
+
+def from_json(obj: ReserveStatusJSON) -> ReserveStatusKind:
+    if obj["kind"] == "Active":
+        return Active()
+    if obj["kind"] == "Obsolete":
+        return Obsolete()
+    if obj["kind"] == "Hidden":
+        return Hidden()
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen(
+    "Active" / borsh.CStruct(), "Obsolete" / borsh.CStruct(), "Hidden" / borsh.CStruct()
+)

--- a/codegen_lend/types/scope_configuration.py
+++ b/codegen_lend/types/scope_configuration.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class ScopeConfigurationJSON(typing.TypedDict):
+    price_feed: str
+    price_chain: list[int]
+    twap_chain: list[int]
+
+
+@dataclass
+class ScopeConfiguration:
+    layout: typing.ClassVar = borsh.CStruct(
+        "price_feed" / BorshPubkey,
+        "price_chain" / borsh.U16[4],
+        "twap_chain" / borsh.U16[4],
+    )
+    price_feed: Pubkey
+    price_chain: list[int]
+    twap_chain: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "ScopeConfiguration":
+        return cls(
+            price_feed=obj.price_feed,
+            price_chain=obj.price_chain,
+            twap_chain=obj.twap_chain,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "price_feed": self.price_feed,
+            "price_chain": self.price_chain,
+            "twap_chain": self.twap_chain,
+        }
+
+    def to_json(self) -> ScopeConfigurationJSON:
+        return {
+            "price_feed": str(self.price_feed),
+            "price_chain": self.price_chain,
+            "twap_chain": self.twap_chain,
+        }
+
+    @classmethod
+    def from_json(cls, obj: ScopeConfigurationJSON) -> "ScopeConfiguration":
+        return cls(
+            price_feed=Pubkey.from_string(obj["price_feed"]),
+            price_chain=obj["price_chain"],
+            twap_chain=obj["twap_chain"],
+        )

--- a/codegen_lend/types/switchboard_configuration.py
+++ b/codegen_lend/types/switchboard_configuration.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import BorshPubkey
+import borsh_construct as borsh
+
+
+class SwitchboardConfigurationJSON(typing.TypedDict):
+    price_aggregator: str
+    twap_aggregator: str
+
+
+@dataclass
+class SwitchboardConfiguration:
+    layout: typing.ClassVar = borsh.CStruct(
+        "price_aggregator" / BorshPubkey, "twap_aggregator" / BorshPubkey
+    )
+    price_aggregator: Pubkey
+    twap_aggregator: Pubkey
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "SwitchboardConfiguration":
+        return cls(
+            price_aggregator=obj.price_aggregator, twap_aggregator=obj.twap_aggregator
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "price_aggregator": self.price_aggregator,
+            "twap_aggregator": self.twap_aggregator,
+        }
+
+    def to_json(self) -> SwitchboardConfigurationJSON:
+        return {
+            "price_aggregator": str(self.price_aggregator),
+            "twap_aggregator": str(self.twap_aggregator),
+        }
+
+    @classmethod
+    def from_json(cls, obj: SwitchboardConfigurationJSON) -> "SwitchboardConfiguration":
+        return cls(
+            price_aggregator=Pubkey.from_string(obj["price_aggregator"]),
+            twap_aggregator=Pubkey.from_string(obj["twap_aggregator"]),
+        )

--- a/codegen_lend/types/token_info.py
+++ b/codegen_lend/types/token_info.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+from . import (
+    price_heuristic,
+    pyth_configuration,
+    scope_configuration,
+    switchboard_configuration,
+)
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class TokenInfoJSON(typing.TypedDict):
+    name: list[int]
+    heuristic: price_heuristic.PriceHeuristicJSON
+    max_twap_divergence_bps: int
+    max_age_price_seconds: int
+    max_age_twap_seconds: int
+    scope_configuration: scope_configuration.ScopeConfigurationJSON
+    switchboard_configuration: switchboard_configuration.SwitchboardConfigurationJSON
+    pyth_configuration: pyth_configuration.PythConfigurationJSON
+    block_price_usage: int
+    reserved: list[int]
+    padding: list[int]
+
+
+@dataclass
+class TokenInfo:
+    layout: typing.ClassVar = borsh.CStruct(
+        "name" / borsh.U8[32],
+        "heuristic" / price_heuristic.PriceHeuristic.layout,
+        "max_twap_divergence_bps" / borsh.U64,
+        "max_age_price_seconds" / borsh.U64,
+        "max_age_twap_seconds" / borsh.U64,
+        "scope_configuration" / scope_configuration.ScopeConfiguration.layout,
+        "switchboard_configuration"
+        / switchboard_configuration.SwitchboardConfiguration.layout,
+        "pyth_configuration" / pyth_configuration.PythConfiguration.layout,
+        "block_price_usage" / borsh.U8,
+        "reserved" / borsh.U8[7],
+        "padding" / borsh.U64[19],
+    )
+    name: list[int]
+    heuristic: price_heuristic.PriceHeuristic
+    max_twap_divergence_bps: int
+    max_age_price_seconds: int
+    max_age_twap_seconds: int
+    scope_configuration: scope_configuration.ScopeConfiguration
+    switchboard_configuration: switchboard_configuration.SwitchboardConfiguration
+    pyth_configuration: pyth_configuration.PythConfiguration
+    block_price_usage: int
+    reserved: list[int]
+    padding: list[int]
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "TokenInfo":
+        return cls(
+            name=obj.name,
+            heuristic=price_heuristic.PriceHeuristic.from_decoded(obj.heuristic),
+            max_twap_divergence_bps=obj.max_twap_divergence_bps,
+            max_age_price_seconds=obj.max_age_price_seconds,
+            max_age_twap_seconds=obj.max_age_twap_seconds,
+            scope_configuration=scope_configuration.ScopeConfiguration.from_decoded(
+                obj.scope_configuration
+            ),
+            switchboard_configuration=switchboard_configuration.SwitchboardConfiguration.from_decoded(
+                obj.switchboard_configuration
+            ),
+            pyth_configuration=pyth_configuration.PythConfiguration.from_decoded(
+                obj.pyth_configuration
+            ),
+            block_price_usage=obj.block_price_usage,
+            reserved=obj.reserved,
+            padding=obj.padding,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "name": self.name,
+            "heuristic": self.heuristic.to_encodable(),
+            "max_twap_divergence_bps": self.max_twap_divergence_bps,
+            "max_age_price_seconds": self.max_age_price_seconds,
+            "max_age_twap_seconds": self.max_age_twap_seconds,
+            "scope_configuration": self.scope_configuration.to_encodable(),
+            "switchboard_configuration": self.switchboard_configuration.to_encodable(),
+            "pyth_configuration": self.pyth_configuration.to_encodable(),
+            "block_price_usage": self.block_price_usage,
+            "reserved": self.reserved,
+            "padding": self.padding,
+        }
+
+    def to_json(self) -> TokenInfoJSON:
+        return {
+            "name": self.name,
+            "heuristic": self.heuristic.to_json(),
+            "max_twap_divergence_bps": self.max_twap_divergence_bps,
+            "max_age_price_seconds": self.max_age_price_seconds,
+            "max_age_twap_seconds": self.max_age_twap_seconds,
+            "scope_configuration": self.scope_configuration.to_json(),
+            "switchboard_configuration": self.switchboard_configuration.to_json(),
+            "pyth_configuration": self.pyth_configuration.to_json(),
+            "block_price_usage": self.block_price_usage,
+            "reserved": self.reserved,
+            "padding": self.padding,
+        }
+
+    @classmethod
+    def from_json(cls, obj: TokenInfoJSON) -> "TokenInfo":
+        return cls(
+            name=obj["name"],
+            heuristic=price_heuristic.PriceHeuristic.from_json(obj["heuristic"]),
+            max_twap_divergence_bps=obj["max_twap_divergence_bps"],
+            max_age_price_seconds=obj["max_age_price_seconds"],
+            max_age_twap_seconds=obj["max_age_twap_seconds"],
+            scope_configuration=scope_configuration.ScopeConfiguration.from_json(
+                obj["scope_configuration"]
+            ),
+            switchboard_configuration=switchboard_configuration.SwitchboardConfiguration.from_json(
+                obj["switchboard_configuration"]
+            ),
+            pyth_configuration=pyth_configuration.PythConfiguration.from_json(
+                obj["pyth_configuration"]
+            ),
+            block_price_usage=obj["block_price_usage"],
+            reserved=obj["reserved"],
+            padding=obj["padding"],
+        )

--- a/codegen_lend/types/update_config_mode.py
+++ b/codegen_lend/types/update_config_mode.py
@@ -1,0 +1,1389 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
+
+
+class UpdateLoanToValuePctJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateLoanToValuePct"]
+
+
+class UpdateMaxLiquidationBonusBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMaxLiquidationBonusBps"]
+
+
+class UpdateLiquidationThresholdPctJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateLiquidationThresholdPct"]
+
+
+class UpdateProtocolLiquidationFeeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateProtocolLiquidationFee"]
+
+
+class UpdateProtocolTakeRateJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateProtocolTakeRate"]
+
+
+class UpdateFeesBorrowFeeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFeesBorrowFee"]
+
+
+class UpdateFeesFlashLoanFeeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFeesFlashLoanFee"]
+
+
+class UpdateFeesReferralFeeBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFeesReferralFeeBps"]
+
+
+class UpdateDepositLimitJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDepositLimit"]
+
+
+class UpdateBorrowLimitJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowLimit"]
+
+
+class UpdateTokenInfoLowerHeuristicJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoLowerHeuristic"]
+
+
+class UpdateTokenInfoUpperHeuristicJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoUpperHeuristic"]
+
+
+class UpdateTokenInfoExpHeuristicJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoExpHeuristic"]
+
+
+class UpdateTokenInfoTwapDivergenceJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoTwapDivergence"]
+
+
+class UpdateTokenInfoScopeTwapJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoScopeTwap"]
+
+
+class UpdateTokenInfoScopeChainJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoScopeChain"]
+
+
+class UpdateTokenInfoNameJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoName"]
+
+
+class UpdateTokenInfoPriceMaxAgeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoPriceMaxAge"]
+
+
+class UpdateTokenInfoTwapMaxAgeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateTokenInfoTwapMaxAge"]
+
+
+class UpdateScopePriceFeedJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateScopePriceFeed"]
+
+
+class UpdatePythPriceJSON(typing.TypedDict):
+    kind: typing.Literal["UpdatePythPrice"]
+
+
+class UpdateSwitchboardFeedJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateSwitchboardFeed"]
+
+
+class UpdateSwitchboardTwapFeedJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateSwitchboardTwapFeed"]
+
+
+class UpdateBorrowRateCurveJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowRateCurve"]
+
+
+class UpdateEntireReserveConfigJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateEntireReserveConfig"]
+
+
+class UpdateDebtWithdrawalCapJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDebtWithdrawalCap"]
+
+
+class UpdateDepositWithdrawalCapJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDepositWithdrawalCap"]
+
+
+class UpdateDebtWithdrawalCapCurrentTotalJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDebtWithdrawalCapCurrentTotal"]
+
+
+class UpdateDepositWithdrawalCapCurrentTotalJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDepositWithdrawalCapCurrentTotal"]
+
+
+class UpdateBadDebtLiquidationBonusBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBadDebtLiquidationBonusBps"]
+
+
+class UpdateMinLiquidationBonusBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMinLiquidationBonusBps"]
+
+
+class DeleveragingMarginCallPeriodJSON(typing.TypedDict):
+    kind: typing.Literal["DeleveragingMarginCallPeriod"]
+
+
+class UpdateBorrowFactorJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowFactor"]
+
+
+class UpdateAssetTierJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateAssetTier"]
+
+
+class UpdateElevationGroupJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateElevationGroup"]
+
+
+class DeleveragingThresholdSlotsPerBpsJSON(typing.TypedDict):
+    kind: typing.Literal["DeleveragingThresholdSlotsPerBps"]
+
+
+class UpdateMultiplierSideBoostJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMultiplierSideBoost"]
+
+
+class UpdateMultiplierTagBoostJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMultiplierTagBoost"]
+
+
+class UpdateReserveStatusJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateReserveStatus"]
+
+
+class UpdateFarmCollateralJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFarmCollateral"]
+
+
+class UpdateFarmDebtJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateFarmDebt"]
+
+
+class UpdateDisableUsageAsCollateralOutsideEmodeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateDisableUsageAsCollateralOutsideEmode"]
+
+
+class UpdateBlockBorrowingAboveUtilizationJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBlockBorrowingAboveUtilization"]
+
+
+class UpdateBlockPriceUsageJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBlockPriceUsage"]
+
+
+class UpdateBorrowLimitOutsideElevationGroupJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowLimitOutsideElevationGroup"]
+
+
+class UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowLimitsInElevationGroupAgainstThisReserve"]
+
+
+class UpdateHostFixedInterestRateBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateHostFixedInterestRateBps"]
+
+
+@dataclass
+class UpdateLoanToValuePct:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "UpdateLoanToValuePct"
+
+    @classmethod
+    def to_json(cls) -> UpdateLoanToValuePctJSON:
+        return UpdateLoanToValuePctJSON(
+            kind="UpdateLoanToValuePct",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateLoanToValuePct": {},
+        }
+
+
+@dataclass
+class UpdateMaxLiquidationBonusBps:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "UpdateMaxLiquidationBonusBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateMaxLiquidationBonusBpsJSON:
+        return UpdateMaxLiquidationBonusBpsJSON(
+            kind="UpdateMaxLiquidationBonusBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMaxLiquidationBonusBps": {},
+        }
+
+
+@dataclass
+class UpdateLiquidationThresholdPct:
+    discriminator: typing.ClassVar = 2
+    kind: typing.ClassVar = "UpdateLiquidationThresholdPct"
+
+    @classmethod
+    def to_json(cls) -> UpdateLiquidationThresholdPctJSON:
+        return UpdateLiquidationThresholdPctJSON(
+            kind="UpdateLiquidationThresholdPct",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateLiquidationThresholdPct": {},
+        }
+
+
+@dataclass
+class UpdateProtocolLiquidationFee:
+    discriminator: typing.ClassVar = 3
+    kind: typing.ClassVar = "UpdateProtocolLiquidationFee"
+
+    @classmethod
+    def to_json(cls) -> UpdateProtocolLiquidationFeeJSON:
+        return UpdateProtocolLiquidationFeeJSON(
+            kind="UpdateProtocolLiquidationFee",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateProtocolLiquidationFee": {},
+        }
+
+
+@dataclass
+class UpdateProtocolTakeRate:
+    discriminator: typing.ClassVar = 4
+    kind: typing.ClassVar = "UpdateProtocolTakeRate"
+
+    @classmethod
+    def to_json(cls) -> UpdateProtocolTakeRateJSON:
+        return UpdateProtocolTakeRateJSON(
+            kind="UpdateProtocolTakeRate",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateProtocolTakeRate": {},
+        }
+
+
+@dataclass
+class UpdateFeesBorrowFee:
+    discriminator: typing.ClassVar = 5
+    kind: typing.ClassVar = "UpdateFeesBorrowFee"
+
+    @classmethod
+    def to_json(cls) -> UpdateFeesBorrowFeeJSON:
+        return UpdateFeesBorrowFeeJSON(
+            kind="UpdateFeesBorrowFee",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFeesBorrowFee": {},
+        }
+
+
+@dataclass
+class UpdateFeesFlashLoanFee:
+    discriminator: typing.ClassVar = 6
+    kind: typing.ClassVar = "UpdateFeesFlashLoanFee"
+
+    @classmethod
+    def to_json(cls) -> UpdateFeesFlashLoanFeeJSON:
+        return UpdateFeesFlashLoanFeeJSON(
+            kind="UpdateFeesFlashLoanFee",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFeesFlashLoanFee": {},
+        }
+
+
+@dataclass
+class UpdateFeesReferralFeeBps:
+    discriminator: typing.ClassVar = 7
+    kind: typing.ClassVar = "UpdateFeesReferralFeeBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateFeesReferralFeeBpsJSON:
+        return UpdateFeesReferralFeeBpsJSON(
+            kind="UpdateFeesReferralFeeBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFeesReferralFeeBps": {},
+        }
+
+
+@dataclass
+class UpdateDepositLimit:
+    discriminator: typing.ClassVar = 8
+    kind: typing.ClassVar = "UpdateDepositLimit"
+
+    @classmethod
+    def to_json(cls) -> UpdateDepositLimitJSON:
+        return UpdateDepositLimitJSON(
+            kind="UpdateDepositLimit",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDepositLimit": {},
+        }
+
+
+@dataclass
+class UpdateBorrowLimit:
+    discriminator: typing.ClassVar = 9
+    kind: typing.ClassVar = "UpdateBorrowLimit"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowLimitJSON:
+        return UpdateBorrowLimitJSON(
+            kind="UpdateBorrowLimit",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowLimit": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoLowerHeuristic:
+    discriminator: typing.ClassVar = 10
+    kind: typing.ClassVar = "UpdateTokenInfoLowerHeuristic"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoLowerHeuristicJSON:
+        return UpdateTokenInfoLowerHeuristicJSON(
+            kind="UpdateTokenInfoLowerHeuristic",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoLowerHeuristic": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoUpperHeuristic:
+    discriminator: typing.ClassVar = 11
+    kind: typing.ClassVar = "UpdateTokenInfoUpperHeuristic"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoUpperHeuristicJSON:
+        return UpdateTokenInfoUpperHeuristicJSON(
+            kind="UpdateTokenInfoUpperHeuristic",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoUpperHeuristic": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoExpHeuristic:
+    discriminator: typing.ClassVar = 12
+    kind: typing.ClassVar = "UpdateTokenInfoExpHeuristic"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoExpHeuristicJSON:
+        return UpdateTokenInfoExpHeuristicJSON(
+            kind="UpdateTokenInfoExpHeuristic",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoExpHeuristic": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoTwapDivergence:
+    discriminator: typing.ClassVar = 13
+    kind: typing.ClassVar = "UpdateTokenInfoTwapDivergence"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoTwapDivergenceJSON:
+        return UpdateTokenInfoTwapDivergenceJSON(
+            kind="UpdateTokenInfoTwapDivergence",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoTwapDivergence": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoScopeTwap:
+    discriminator: typing.ClassVar = 14
+    kind: typing.ClassVar = "UpdateTokenInfoScopeTwap"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoScopeTwapJSON:
+        return UpdateTokenInfoScopeTwapJSON(
+            kind="UpdateTokenInfoScopeTwap",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoScopeTwap": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoScopeChain:
+    discriminator: typing.ClassVar = 15
+    kind: typing.ClassVar = "UpdateTokenInfoScopeChain"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoScopeChainJSON:
+        return UpdateTokenInfoScopeChainJSON(
+            kind="UpdateTokenInfoScopeChain",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoScopeChain": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoName:
+    discriminator: typing.ClassVar = 16
+    kind: typing.ClassVar = "UpdateTokenInfoName"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoNameJSON:
+        return UpdateTokenInfoNameJSON(
+            kind="UpdateTokenInfoName",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoName": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoPriceMaxAge:
+    discriminator: typing.ClassVar = 17
+    kind: typing.ClassVar = "UpdateTokenInfoPriceMaxAge"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoPriceMaxAgeJSON:
+        return UpdateTokenInfoPriceMaxAgeJSON(
+            kind="UpdateTokenInfoPriceMaxAge",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoPriceMaxAge": {},
+        }
+
+
+@dataclass
+class UpdateTokenInfoTwapMaxAge:
+    discriminator: typing.ClassVar = 18
+    kind: typing.ClassVar = "UpdateTokenInfoTwapMaxAge"
+
+    @classmethod
+    def to_json(cls) -> UpdateTokenInfoTwapMaxAgeJSON:
+        return UpdateTokenInfoTwapMaxAgeJSON(
+            kind="UpdateTokenInfoTwapMaxAge",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateTokenInfoTwapMaxAge": {},
+        }
+
+
+@dataclass
+class UpdateScopePriceFeed:
+    discriminator: typing.ClassVar = 19
+    kind: typing.ClassVar = "UpdateScopePriceFeed"
+
+    @classmethod
+    def to_json(cls) -> UpdateScopePriceFeedJSON:
+        return UpdateScopePriceFeedJSON(
+            kind="UpdateScopePriceFeed",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateScopePriceFeed": {},
+        }
+
+
+@dataclass
+class UpdatePythPrice:
+    discriminator: typing.ClassVar = 20
+    kind: typing.ClassVar = "UpdatePythPrice"
+
+    @classmethod
+    def to_json(cls) -> UpdatePythPriceJSON:
+        return UpdatePythPriceJSON(
+            kind="UpdatePythPrice",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdatePythPrice": {},
+        }
+
+
+@dataclass
+class UpdateSwitchboardFeed:
+    discriminator: typing.ClassVar = 21
+    kind: typing.ClassVar = "UpdateSwitchboardFeed"
+
+    @classmethod
+    def to_json(cls) -> UpdateSwitchboardFeedJSON:
+        return UpdateSwitchboardFeedJSON(
+            kind="UpdateSwitchboardFeed",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateSwitchboardFeed": {},
+        }
+
+
+@dataclass
+class UpdateSwitchboardTwapFeed:
+    discriminator: typing.ClassVar = 22
+    kind: typing.ClassVar = "UpdateSwitchboardTwapFeed"
+
+    @classmethod
+    def to_json(cls) -> UpdateSwitchboardTwapFeedJSON:
+        return UpdateSwitchboardTwapFeedJSON(
+            kind="UpdateSwitchboardTwapFeed",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateSwitchboardTwapFeed": {},
+        }
+
+
+@dataclass
+class UpdateBorrowRateCurve:
+    discriminator: typing.ClassVar = 23
+    kind: typing.ClassVar = "UpdateBorrowRateCurve"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowRateCurveJSON:
+        return UpdateBorrowRateCurveJSON(
+            kind="UpdateBorrowRateCurve",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowRateCurve": {},
+        }
+
+
+@dataclass
+class UpdateEntireReserveConfig:
+    discriminator: typing.ClassVar = 24
+    kind: typing.ClassVar = "UpdateEntireReserveConfig"
+
+    @classmethod
+    def to_json(cls) -> UpdateEntireReserveConfigJSON:
+        return UpdateEntireReserveConfigJSON(
+            kind="UpdateEntireReserveConfig",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateEntireReserveConfig": {},
+        }
+
+
+@dataclass
+class UpdateDebtWithdrawalCap:
+    discriminator: typing.ClassVar = 25
+    kind: typing.ClassVar = "UpdateDebtWithdrawalCap"
+
+    @classmethod
+    def to_json(cls) -> UpdateDebtWithdrawalCapJSON:
+        return UpdateDebtWithdrawalCapJSON(
+            kind="UpdateDebtWithdrawalCap",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDebtWithdrawalCap": {},
+        }
+
+
+@dataclass
+class UpdateDepositWithdrawalCap:
+    discriminator: typing.ClassVar = 26
+    kind: typing.ClassVar = "UpdateDepositWithdrawalCap"
+
+    @classmethod
+    def to_json(cls) -> UpdateDepositWithdrawalCapJSON:
+        return UpdateDepositWithdrawalCapJSON(
+            kind="UpdateDepositWithdrawalCap",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDepositWithdrawalCap": {},
+        }
+
+
+@dataclass
+class UpdateDebtWithdrawalCapCurrentTotal:
+    discriminator: typing.ClassVar = 27
+    kind: typing.ClassVar = "UpdateDebtWithdrawalCapCurrentTotal"
+
+    @classmethod
+    def to_json(cls) -> UpdateDebtWithdrawalCapCurrentTotalJSON:
+        return UpdateDebtWithdrawalCapCurrentTotalJSON(
+            kind="UpdateDebtWithdrawalCapCurrentTotal",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDebtWithdrawalCapCurrentTotal": {},
+        }
+
+
+@dataclass
+class UpdateDepositWithdrawalCapCurrentTotal:
+    discriminator: typing.ClassVar = 28
+    kind: typing.ClassVar = "UpdateDepositWithdrawalCapCurrentTotal"
+
+    @classmethod
+    def to_json(cls) -> UpdateDepositWithdrawalCapCurrentTotalJSON:
+        return UpdateDepositWithdrawalCapCurrentTotalJSON(
+            kind="UpdateDepositWithdrawalCapCurrentTotal",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDepositWithdrawalCapCurrentTotal": {},
+        }
+
+
+@dataclass
+class UpdateBadDebtLiquidationBonusBps:
+    discriminator: typing.ClassVar = 29
+    kind: typing.ClassVar = "UpdateBadDebtLiquidationBonusBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateBadDebtLiquidationBonusBpsJSON:
+        return UpdateBadDebtLiquidationBonusBpsJSON(
+            kind="UpdateBadDebtLiquidationBonusBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBadDebtLiquidationBonusBps": {},
+        }
+
+
+@dataclass
+class UpdateMinLiquidationBonusBps:
+    discriminator: typing.ClassVar = 30
+    kind: typing.ClassVar = "UpdateMinLiquidationBonusBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateMinLiquidationBonusBpsJSON:
+        return UpdateMinLiquidationBonusBpsJSON(
+            kind="UpdateMinLiquidationBonusBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMinLiquidationBonusBps": {},
+        }
+
+
+@dataclass
+class DeleveragingMarginCallPeriod:
+    discriminator: typing.ClassVar = 31
+    kind: typing.ClassVar = "DeleveragingMarginCallPeriod"
+
+    @classmethod
+    def to_json(cls) -> DeleveragingMarginCallPeriodJSON:
+        return DeleveragingMarginCallPeriodJSON(
+            kind="DeleveragingMarginCallPeriod",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "DeleveragingMarginCallPeriod": {},
+        }
+
+
+@dataclass
+class UpdateBorrowFactor:
+    discriminator: typing.ClassVar = 32
+    kind: typing.ClassVar = "UpdateBorrowFactor"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowFactorJSON:
+        return UpdateBorrowFactorJSON(
+            kind="UpdateBorrowFactor",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowFactor": {},
+        }
+
+
+@dataclass
+class UpdateAssetTier:
+    discriminator: typing.ClassVar = 33
+    kind: typing.ClassVar = "UpdateAssetTier"
+
+    @classmethod
+    def to_json(cls) -> UpdateAssetTierJSON:
+        return UpdateAssetTierJSON(
+            kind="UpdateAssetTier",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateAssetTier": {},
+        }
+
+
+@dataclass
+class UpdateElevationGroup:
+    discriminator: typing.ClassVar = 34
+    kind: typing.ClassVar = "UpdateElevationGroup"
+
+    @classmethod
+    def to_json(cls) -> UpdateElevationGroupJSON:
+        return UpdateElevationGroupJSON(
+            kind="UpdateElevationGroup",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateElevationGroup": {},
+        }
+
+
+@dataclass
+class DeleveragingThresholdSlotsPerBps:
+    discriminator: typing.ClassVar = 35
+    kind: typing.ClassVar = "DeleveragingThresholdSlotsPerBps"
+
+    @classmethod
+    def to_json(cls) -> DeleveragingThresholdSlotsPerBpsJSON:
+        return DeleveragingThresholdSlotsPerBpsJSON(
+            kind="DeleveragingThresholdSlotsPerBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "DeleveragingThresholdSlotsPerBps": {},
+        }
+
+
+@dataclass
+class UpdateMultiplierSideBoost:
+    discriminator: typing.ClassVar = 36
+    kind: typing.ClassVar = "UpdateMultiplierSideBoost"
+
+    @classmethod
+    def to_json(cls) -> UpdateMultiplierSideBoostJSON:
+        return UpdateMultiplierSideBoostJSON(
+            kind="UpdateMultiplierSideBoost",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMultiplierSideBoost": {},
+        }
+
+
+@dataclass
+class UpdateMultiplierTagBoost:
+    discriminator: typing.ClassVar = 37
+    kind: typing.ClassVar = "UpdateMultiplierTagBoost"
+
+    @classmethod
+    def to_json(cls) -> UpdateMultiplierTagBoostJSON:
+        return UpdateMultiplierTagBoostJSON(
+            kind="UpdateMultiplierTagBoost",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMultiplierTagBoost": {},
+        }
+
+
+@dataclass
+class UpdateReserveStatus:
+    discriminator: typing.ClassVar = 38
+    kind: typing.ClassVar = "UpdateReserveStatus"
+
+    @classmethod
+    def to_json(cls) -> UpdateReserveStatusJSON:
+        return UpdateReserveStatusJSON(
+            kind="UpdateReserveStatus",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateReserveStatus": {},
+        }
+
+
+@dataclass
+class UpdateFarmCollateral:
+    discriminator: typing.ClassVar = 39
+    kind: typing.ClassVar = "UpdateFarmCollateral"
+
+    @classmethod
+    def to_json(cls) -> UpdateFarmCollateralJSON:
+        return UpdateFarmCollateralJSON(
+            kind="UpdateFarmCollateral",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFarmCollateral": {},
+        }
+
+
+@dataclass
+class UpdateFarmDebt:
+    discriminator: typing.ClassVar = 40
+    kind: typing.ClassVar = "UpdateFarmDebt"
+
+    @classmethod
+    def to_json(cls) -> UpdateFarmDebtJSON:
+        return UpdateFarmDebtJSON(
+            kind="UpdateFarmDebt",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateFarmDebt": {},
+        }
+
+
+@dataclass
+class UpdateDisableUsageAsCollateralOutsideEmode:
+    discriminator: typing.ClassVar = 41
+    kind: typing.ClassVar = "UpdateDisableUsageAsCollateralOutsideEmode"
+
+    @classmethod
+    def to_json(cls) -> UpdateDisableUsageAsCollateralOutsideEmodeJSON:
+        return UpdateDisableUsageAsCollateralOutsideEmodeJSON(
+            kind="UpdateDisableUsageAsCollateralOutsideEmode",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateDisableUsageAsCollateralOutsideEmode": {},
+        }
+
+
+@dataclass
+class UpdateBlockBorrowingAboveUtilization:
+    discriminator: typing.ClassVar = 42
+    kind: typing.ClassVar = "UpdateBlockBorrowingAboveUtilization"
+
+    @classmethod
+    def to_json(cls) -> UpdateBlockBorrowingAboveUtilizationJSON:
+        return UpdateBlockBorrowingAboveUtilizationJSON(
+            kind="UpdateBlockBorrowingAboveUtilization",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBlockBorrowingAboveUtilization": {},
+        }
+
+
+@dataclass
+class UpdateBlockPriceUsage:
+    discriminator: typing.ClassVar = 43
+    kind: typing.ClassVar = "UpdateBlockPriceUsage"
+
+    @classmethod
+    def to_json(cls) -> UpdateBlockPriceUsageJSON:
+        return UpdateBlockPriceUsageJSON(
+            kind="UpdateBlockPriceUsage",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBlockPriceUsage": {},
+        }
+
+
+@dataclass
+class UpdateBorrowLimitOutsideElevationGroup:
+    discriminator: typing.ClassVar = 44
+    kind: typing.ClassVar = "UpdateBorrowLimitOutsideElevationGroup"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowLimitOutsideElevationGroupJSON:
+        return UpdateBorrowLimitOutsideElevationGroupJSON(
+            kind="UpdateBorrowLimitOutsideElevationGroup",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowLimitOutsideElevationGroup": {},
+        }
+
+
+@dataclass
+class UpdateBorrowLimitsInElevationGroupAgainstThisReserve:
+    discriminator: typing.ClassVar = 45
+    kind: typing.ClassVar = "UpdateBorrowLimitsInElevationGroupAgainstThisReserve"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON:
+        return UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON(
+            kind="UpdateBorrowLimitsInElevationGroupAgainstThisReserve",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowLimitsInElevationGroupAgainstThisReserve": {},
+        }
+
+
+@dataclass
+class UpdateHostFixedInterestRateBps:
+    discriminator: typing.ClassVar = 46
+    kind: typing.ClassVar = "UpdateHostFixedInterestRateBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateHostFixedInterestRateBpsJSON:
+        return UpdateHostFixedInterestRateBpsJSON(
+            kind="UpdateHostFixedInterestRateBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateHostFixedInterestRateBps": {},
+        }
+
+
+UpdateConfigModeKind = typing.Union[
+    UpdateLoanToValuePct,
+    UpdateMaxLiquidationBonusBps,
+    UpdateLiquidationThresholdPct,
+    UpdateProtocolLiquidationFee,
+    UpdateProtocolTakeRate,
+    UpdateFeesBorrowFee,
+    UpdateFeesFlashLoanFee,
+    UpdateFeesReferralFeeBps,
+    UpdateDepositLimit,
+    UpdateBorrowLimit,
+    UpdateTokenInfoLowerHeuristic,
+    UpdateTokenInfoUpperHeuristic,
+    UpdateTokenInfoExpHeuristic,
+    UpdateTokenInfoTwapDivergence,
+    UpdateTokenInfoScopeTwap,
+    UpdateTokenInfoScopeChain,
+    UpdateTokenInfoName,
+    UpdateTokenInfoPriceMaxAge,
+    UpdateTokenInfoTwapMaxAge,
+    UpdateScopePriceFeed,
+    UpdatePythPrice,
+    UpdateSwitchboardFeed,
+    UpdateSwitchboardTwapFeed,
+    UpdateBorrowRateCurve,
+    UpdateEntireReserveConfig,
+    UpdateDebtWithdrawalCap,
+    UpdateDepositWithdrawalCap,
+    UpdateDebtWithdrawalCapCurrentTotal,
+    UpdateDepositWithdrawalCapCurrentTotal,
+    UpdateBadDebtLiquidationBonusBps,
+    UpdateMinLiquidationBonusBps,
+    DeleveragingMarginCallPeriod,
+    UpdateBorrowFactor,
+    UpdateAssetTier,
+    UpdateElevationGroup,
+    DeleveragingThresholdSlotsPerBps,
+    UpdateMultiplierSideBoost,
+    UpdateMultiplierTagBoost,
+    UpdateReserveStatus,
+    UpdateFarmCollateral,
+    UpdateFarmDebt,
+    UpdateDisableUsageAsCollateralOutsideEmode,
+    UpdateBlockBorrowingAboveUtilization,
+    UpdateBlockPriceUsage,
+    UpdateBorrowLimitOutsideElevationGroup,
+    UpdateBorrowLimitsInElevationGroupAgainstThisReserve,
+    UpdateHostFixedInterestRateBps,
+]
+UpdateConfigModeJSON = typing.Union[
+    UpdateLoanToValuePctJSON,
+    UpdateMaxLiquidationBonusBpsJSON,
+    UpdateLiquidationThresholdPctJSON,
+    UpdateProtocolLiquidationFeeJSON,
+    UpdateProtocolTakeRateJSON,
+    UpdateFeesBorrowFeeJSON,
+    UpdateFeesFlashLoanFeeJSON,
+    UpdateFeesReferralFeeBpsJSON,
+    UpdateDepositLimitJSON,
+    UpdateBorrowLimitJSON,
+    UpdateTokenInfoLowerHeuristicJSON,
+    UpdateTokenInfoUpperHeuristicJSON,
+    UpdateTokenInfoExpHeuristicJSON,
+    UpdateTokenInfoTwapDivergenceJSON,
+    UpdateTokenInfoScopeTwapJSON,
+    UpdateTokenInfoScopeChainJSON,
+    UpdateTokenInfoNameJSON,
+    UpdateTokenInfoPriceMaxAgeJSON,
+    UpdateTokenInfoTwapMaxAgeJSON,
+    UpdateScopePriceFeedJSON,
+    UpdatePythPriceJSON,
+    UpdateSwitchboardFeedJSON,
+    UpdateSwitchboardTwapFeedJSON,
+    UpdateBorrowRateCurveJSON,
+    UpdateEntireReserveConfigJSON,
+    UpdateDebtWithdrawalCapJSON,
+    UpdateDepositWithdrawalCapJSON,
+    UpdateDebtWithdrawalCapCurrentTotalJSON,
+    UpdateDepositWithdrawalCapCurrentTotalJSON,
+    UpdateBadDebtLiquidationBonusBpsJSON,
+    UpdateMinLiquidationBonusBpsJSON,
+    DeleveragingMarginCallPeriodJSON,
+    UpdateBorrowFactorJSON,
+    UpdateAssetTierJSON,
+    UpdateElevationGroupJSON,
+    DeleveragingThresholdSlotsPerBpsJSON,
+    UpdateMultiplierSideBoostJSON,
+    UpdateMultiplierTagBoostJSON,
+    UpdateReserveStatusJSON,
+    UpdateFarmCollateralJSON,
+    UpdateFarmDebtJSON,
+    UpdateDisableUsageAsCollateralOutsideEmodeJSON,
+    UpdateBlockBorrowingAboveUtilizationJSON,
+    UpdateBlockPriceUsageJSON,
+    UpdateBorrowLimitOutsideElevationGroupJSON,
+    UpdateBorrowLimitsInElevationGroupAgainstThisReserveJSON,
+    UpdateHostFixedInterestRateBpsJSON,
+]
+
+
+def from_decoded(obj: dict) -> UpdateConfigModeKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "UpdateLoanToValuePct" in obj:
+        return UpdateLoanToValuePct()
+    if "UpdateMaxLiquidationBonusBps" in obj:
+        return UpdateMaxLiquidationBonusBps()
+    if "UpdateLiquidationThresholdPct" in obj:
+        return UpdateLiquidationThresholdPct()
+    if "UpdateProtocolLiquidationFee" in obj:
+        return UpdateProtocolLiquidationFee()
+    if "UpdateProtocolTakeRate" in obj:
+        return UpdateProtocolTakeRate()
+    if "UpdateFeesBorrowFee" in obj:
+        return UpdateFeesBorrowFee()
+    if "UpdateFeesFlashLoanFee" in obj:
+        return UpdateFeesFlashLoanFee()
+    if "UpdateFeesReferralFeeBps" in obj:
+        return UpdateFeesReferralFeeBps()
+    if "UpdateDepositLimit" in obj:
+        return UpdateDepositLimit()
+    if "UpdateBorrowLimit" in obj:
+        return UpdateBorrowLimit()
+    if "UpdateTokenInfoLowerHeuristic" in obj:
+        return UpdateTokenInfoLowerHeuristic()
+    if "UpdateTokenInfoUpperHeuristic" in obj:
+        return UpdateTokenInfoUpperHeuristic()
+    if "UpdateTokenInfoExpHeuristic" in obj:
+        return UpdateTokenInfoExpHeuristic()
+    if "UpdateTokenInfoTwapDivergence" in obj:
+        return UpdateTokenInfoTwapDivergence()
+    if "UpdateTokenInfoScopeTwap" in obj:
+        return UpdateTokenInfoScopeTwap()
+    if "UpdateTokenInfoScopeChain" in obj:
+        return UpdateTokenInfoScopeChain()
+    if "UpdateTokenInfoName" in obj:
+        return UpdateTokenInfoName()
+    if "UpdateTokenInfoPriceMaxAge" in obj:
+        return UpdateTokenInfoPriceMaxAge()
+    if "UpdateTokenInfoTwapMaxAge" in obj:
+        return UpdateTokenInfoTwapMaxAge()
+    if "UpdateScopePriceFeed" in obj:
+        return UpdateScopePriceFeed()
+    if "UpdatePythPrice" in obj:
+        return UpdatePythPrice()
+    if "UpdateSwitchboardFeed" in obj:
+        return UpdateSwitchboardFeed()
+    if "UpdateSwitchboardTwapFeed" in obj:
+        return UpdateSwitchboardTwapFeed()
+    if "UpdateBorrowRateCurve" in obj:
+        return UpdateBorrowRateCurve()
+    if "UpdateEntireReserveConfig" in obj:
+        return UpdateEntireReserveConfig()
+    if "UpdateDebtWithdrawalCap" in obj:
+        return UpdateDebtWithdrawalCap()
+    if "UpdateDepositWithdrawalCap" in obj:
+        return UpdateDepositWithdrawalCap()
+    if "UpdateDebtWithdrawalCapCurrentTotal" in obj:
+        return UpdateDebtWithdrawalCapCurrentTotal()
+    if "UpdateDepositWithdrawalCapCurrentTotal" in obj:
+        return UpdateDepositWithdrawalCapCurrentTotal()
+    if "UpdateBadDebtLiquidationBonusBps" in obj:
+        return UpdateBadDebtLiquidationBonusBps()
+    if "UpdateMinLiquidationBonusBps" in obj:
+        return UpdateMinLiquidationBonusBps()
+    if "DeleveragingMarginCallPeriod" in obj:
+        return DeleveragingMarginCallPeriod()
+    if "UpdateBorrowFactor" in obj:
+        return UpdateBorrowFactor()
+    if "UpdateAssetTier" in obj:
+        return UpdateAssetTier()
+    if "UpdateElevationGroup" in obj:
+        return UpdateElevationGroup()
+    if "DeleveragingThresholdSlotsPerBps" in obj:
+        return DeleveragingThresholdSlotsPerBps()
+    if "UpdateMultiplierSideBoost" in obj:
+        return UpdateMultiplierSideBoost()
+    if "UpdateMultiplierTagBoost" in obj:
+        return UpdateMultiplierTagBoost()
+    if "UpdateReserveStatus" in obj:
+        return UpdateReserveStatus()
+    if "UpdateFarmCollateral" in obj:
+        return UpdateFarmCollateral()
+    if "UpdateFarmDebt" in obj:
+        return UpdateFarmDebt()
+    if "UpdateDisableUsageAsCollateralOutsideEmode" in obj:
+        return UpdateDisableUsageAsCollateralOutsideEmode()
+    if "UpdateBlockBorrowingAboveUtilization" in obj:
+        return UpdateBlockBorrowingAboveUtilization()
+    if "UpdateBlockPriceUsage" in obj:
+        return UpdateBlockPriceUsage()
+    if "UpdateBorrowLimitOutsideElevationGroup" in obj:
+        return UpdateBorrowLimitOutsideElevationGroup()
+    if "UpdateBorrowLimitsInElevationGroupAgainstThisReserve" in obj:
+        return UpdateBorrowLimitsInElevationGroupAgainstThisReserve()
+    if "UpdateHostFixedInterestRateBps" in obj:
+        return UpdateHostFixedInterestRateBps()
+    raise ValueError("Invalid enum object")
+
+
+def from_json(obj: UpdateConfigModeJSON) -> UpdateConfigModeKind:
+    if obj["kind"] == "UpdateLoanToValuePct":
+        return UpdateLoanToValuePct()
+    if obj["kind"] == "UpdateMaxLiquidationBonusBps":
+        return UpdateMaxLiquidationBonusBps()
+    if obj["kind"] == "UpdateLiquidationThresholdPct":
+        return UpdateLiquidationThresholdPct()
+    if obj["kind"] == "UpdateProtocolLiquidationFee":
+        return UpdateProtocolLiquidationFee()
+    if obj["kind"] == "UpdateProtocolTakeRate":
+        return UpdateProtocolTakeRate()
+    if obj["kind"] == "UpdateFeesBorrowFee":
+        return UpdateFeesBorrowFee()
+    if obj["kind"] == "UpdateFeesFlashLoanFee":
+        return UpdateFeesFlashLoanFee()
+    if obj["kind"] == "UpdateFeesReferralFeeBps":
+        return UpdateFeesReferralFeeBps()
+    if obj["kind"] == "UpdateDepositLimit":
+        return UpdateDepositLimit()
+    if obj["kind"] == "UpdateBorrowLimit":
+        return UpdateBorrowLimit()
+    if obj["kind"] == "UpdateTokenInfoLowerHeuristic":
+        return UpdateTokenInfoLowerHeuristic()
+    if obj["kind"] == "UpdateTokenInfoUpperHeuristic":
+        return UpdateTokenInfoUpperHeuristic()
+    if obj["kind"] == "UpdateTokenInfoExpHeuristic":
+        return UpdateTokenInfoExpHeuristic()
+    if obj["kind"] == "UpdateTokenInfoTwapDivergence":
+        return UpdateTokenInfoTwapDivergence()
+    if obj["kind"] == "UpdateTokenInfoScopeTwap":
+        return UpdateTokenInfoScopeTwap()
+    if obj["kind"] == "UpdateTokenInfoScopeChain":
+        return UpdateTokenInfoScopeChain()
+    if obj["kind"] == "UpdateTokenInfoName":
+        return UpdateTokenInfoName()
+    if obj["kind"] == "UpdateTokenInfoPriceMaxAge":
+        return UpdateTokenInfoPriceMaxAge()
+    if obj["kind"] == "UpdateTokenInfoTwapMaxAge":
+        return UpdateTokenInfoTwapMaxAge()
+    if obj["kind"] == "UpdateScopePriceFeed":
+        return UpdateScopePriceFeed()
+    if obj["kind"] == "UpdatePythPrice":
+        return UpdatePythPrice()
+    if obj["kind"] == "UpdateSwitchboardFeed":
+        return UpdateSwitchboardFeed()
+    if obj["kind"] == "UpdateSwitchboardTwapFeed":
+        return UpdateSwitchboardTwapFeed()
+    if obj["kind"] == "UpdateBorrowRateCurve":
+        return UpdateBorrowRateCurve()
+    if obj["kind"] == "UpdateEntireReserveConfig":
+        return UpdateEntireReserveConfig()
+    if obj["kind"] == "UpdateDebtWithdrawalCap":
+        return UpdateDebtWithdrawalCap()
+    if obj["kind"] == "UpdateDepositWithdrawalCap":
+        return UpdateDepositWithdrawalCap()
+    if obj["kind"] == "UpdateDebtWithdrawalCapCurrentTotal":
+        return UpdateDebtWithdrawalCapCurrentTotal()
+    if obj["kind"] == "UpdateDepositWithdrawalCapCurrentTotal":
+        return UpdateDepositWithdrawalCapCurrentTotal()
+    if obj["kind"] == "UpdateBadDebtLiquidationBonusBps":
+        return UpdateBadDebtLiquidationBonusBps()
+    if obj["kind"] == "UpdateMinLiquidationBonusBps":
+        return UpdateMinLiquidationBonusBps()
+    if obj["kind"] == "DeleveragingMarginCallPeriod":
+        return DeleveragingMarginCallPeriod()
+    if obj["kind"] == "UpdateBorrowFactor":
+        return UpdateBorrowFactor()
+    if obj["kind"] == "UpdateAssetTier":
+        return UpdateAssetTier()
+    if obj["kind"] == "UpdateElevationGroup":
+        return UpdateElevationGroup()
+    if obj["kind"] == "DeleveragingThresholdSlotsPerBps":
+        return DeleveragingThresholdSlotsPerBps()
+    if obj["kind"] == "UpdateMultiplierSideBoost":
+        return UpdateMultiplierSideBoost()
+    if obj["kind"] == "UpdateMultiplierTagBoost":
+        return UpdateMultiplierTagBoost()
+    if obj["kind"] == "UpdateReserveStatus":
+        return UpdateReserveStatus()
+    if obj["kind"] == "UpdateFarmCollateral":
+        return UpdateFarmCollateral()
+    if obj["kind"] == "UpdateFarmDebt":
+        return UpdateFarmDebt()
+    if obj["kind"] == "UpdateDisableUsageAsCollateralOutsideEmode":
+        return UpdateDisableUsageAsCollateralOutsideEmode()
+    if obj["kind"] == "UpdateBlockBorrowingAboveUtilization":
+        return UpdateBlockBorrowingAboveUtilization()
+    if obj["kind"] == "UpdateBlockPriceUsage":
+        return UpdateBlockPriceUsage()
+    if obj["kind"] == "UpdateBorrowLimitOutsideElevationGroup":
+        return UpdateBorrowLimitOutsideElevationGroup()
+    if obj["kind"] == "UpdateBorrowLimitsInElevationGroupAgainstThisReserve":
+        return UpdateBorrowLimitsInElevationGroupAgainstThisReserve()
+    if obj["kind"] == "UpdateHostFixedInterestRateBps":
+        return UpdateHostFixedInterestRateBps()
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen(
+    "UpdateLoanToValuePct" / borsh.CStruct(),
+    "UpdateMaxLiquidationBonusBps" / borsh.CStruct(),
+    "UpdateLiquidationThresholdPct" / borsh.CStruct(),
+    "UpdateProtocolLiquidationFee" / borsh.CStruct(),
+    "UpdateProtocolTakeRate" / borsh.CStruct(),
+    "UpdateFeesBorrowFee" / borsh.CStruct(),
+    "UpdateFeesFlashLoanFee" / borsh.CStruct(),
+    "UpdateFeesReferralFeeBps" / borsh.CStruct(),
+    "UpdateDepositLimit" / borsh.CStruct(),
+    "UpdateBorrowLimit" / borsh.CStruct(),
+    "UpdateTokenInfoLowerHeuristic" / borsh.CStruct(),
+    "UpdateTokenInfoUpperHeuristic" / borsh.CStruct(),
+    "UpdateTokenInfoExpHeuristic" / borsh.CStruct(),
+    "UpdateTokenInfoTwapDivergence" / borsh.CStruct(),
+    "UpdateTokenInfoScopeTwap" / borsh.CStruct(),
+    "UpdateTokenInfoScopeChain" / borsh.CStruct(),
+    "UpdateTokenInfoName" / borsh.CStruct(),
+    "UpdateTokenInfoPriceMaxAge" / borsh.CStruct(),
+    "UpdateTokenInfoTwapMaxAge" / borsh.CStruct(),
+    "UpdateScopePriceFeed" / borsh.CStruct(),
+    "UpdatePythPrice" / borsh.CStruct(),
+    "UpdateSwitchboardFeed" / borsh.CStruct(),
+    "UpdateSwitchboardTwapFeed" / borsh.CStruct(),
+    "UpdateBorrowRateCurve" / borsh.CStruct(),
+    "UpdateEntireReserveConfig" / borsh.CStruct(),
+    "UpdateDebtWithdrawalCap" / borsh.CStruct(),
+    "UpdateDepositWithdrawalCap" / borsh.CStruct(),
+    "UpdateDebtWithdrawalCapCurrentTotal" / borsh.CStruct(),
+    "UpdateDepositWithdrawalCapCurrentTotal" / borsh.CStruct(),
+    "UpdateBadDebtLiquidationBonusBps" / borsh.CStruct(),
+    "UpdateMinLiquidationBonusBps" / borsh.CStruct(),
+    "DeleveragingMarginCallPeriod" / borsh.CStruct(),
+    "UpdateBorrowFactor" / borsh.CStruct(),
+    "UpdateAssetTier" / borsh.CStruct(),
+    "UpdateElevationGroup" / borsh.CStruct(),
+    "DeleveragingThresholdSlotsPerBps" / borsh.CStruct(),
+    "UpdateMultiplierSideBoost" / borsh.CStruct(),
+    "UpdateMultiplierTagBoost" / borsh.CStruct(),
+    "UpdateReserveStatus" / borsh.CStruct(),
+    "UpdateFarmCollateral" / borsh.CStruct(),
+    "UpdateFarmDebt" / borsh.CStruct(),
+    "UpdateDisableUsageAsCollateralOutsideEmode" / borsh.CStruct(),
+    "UpdateBlockBorrowingAboveUtilization" / borsh.CStruct(),
+    "UpdateBlockPriceUsage" / borsh.CStruct(),
+    "UpdateBorrowLimitOutsideElevationGroup" / borsh.CStruct(),
+    "UpdateBorrowLimitsInElevationGroupAgainstThisReserve" / borsh.CStruct(),
+    "UpdateHostFixedInterestRateBps" / borsh.CStruct(),
+)

--- a/codegen_lend/types/update_lending_market_config_value.py
+++ b/codegen_lend/types/update_lending_market_config_value.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+from . import (
+    elevation_group,
+)
+import typing
+from dataclasses import dataclass
+from solders.pubkey import Pubkey
+from anchorpy.borsh_extension import EnumForCodegen, BorshPubkey
+import borsh_construct as borsh
+
+BoolJSONValue = tuple[bool]
+U8JSONValue = tuple[int]
+U8ArrayJSONValue = tuple[list[int]]
+U16JSONValue = tuple[int]
+U64JSONValue = tuple[int]
+U128JSONValue = tuple[int]
+PubkeyJSONValue = tuple[str]
+ElevationGroupJSONValue = tuple[elevation_group.ElevationGroupJSON]
+BoolValue = tuple[bool]
+U8Value = tuple[int]
+U8ArrayValue = tuple[list[int]]
+U16Value = tuple[int]
+U64Value = tuple[int]
+U128Value = tuple[int]
+PubkeyValue = tuple[Pubkey]
+ElevationGroupValue = tuple[elevation_group.ElevationGroup]
+
+
+class BoolJSON(typing.TypedDict):
+    value: BoolJSONValue
+    kind: typing.Literal["Bool"]
+
+
+class U8JSON(typing.TypedDict):
+    value: U8JSONValue
+    kind: typing.Literal["U8"]
+
+
+class U8ArrayJSON(typing.TypedDict):
+    value: U8ArrayJSONValue
+    kind: typing.Literal["U8Array"]
+
+
+class U16JSON(typing.TypedDict):
+    value: U16JSONValue
+    kind: typing.Literal["U16"]
+
+
+class U64JSON(typing.TypedDict):
+    value: U64JSONValue
+    kind: typing.Literal["U64"]
+
+
+class U128JSON(typing.TypedDict):
+    value: U128JSONValue
+    kind: typing.Literal["U128"]
+
+
+class PubkeyJSON(typing.TypedDict):
+    value: PubkeyJSONValue
+    kind: typing.Literal["Pubkey"]
+
+
+class ElevationGroupJSON(typing.TypedDict):
+    value: ElevationGroupJSONValue
+    kind: typing.Literal["ElevationGroup"]
+
+
+@dataclass
+class Bool:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "Bool"
+    value: BoolValue
+
+    def to_json(self) -> BoolJSON:
+        return BoolJSON(
+            kind="Bool",
+            value=(self.value[0],),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "Bool": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class U8:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "U8"
+    value: U8Value
+
+    def to_json(self) -> U8JSON:
+        return U8JSON(
+            kind="U8",
+            value=(self.value[0],),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "U8": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class U8Array:
+    discriminator: typing.ClassVar = 2
+    kind: typing.ClassVar = "U8Array"
+    value: U8ArrayValue
+
+    def to_json(self) -> U8ArrayJSON:
+        return U8ArrayJSON(
+            kind="U8Array",
+            value=(self.value[0],),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "U8Array": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class U16:
+    discriminator: typing.ClassVar = 3
+    kind: typing.ClassVar = "U16"
+    value: U16Value
+
+    def to_json(self) -> U16JSON:
+        return U16JSON(
+            kind="U16",
+            value=(self.value[0],),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "U16": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class U64:
+    discriminator: typing.ClassVar = 4
+    kind: typing.ClassVar = "U64"
+    value: U64Value
+
+    def to_json(self) -> U64JSON:
+        return U64JSON(
+            kind="U64",
+            value=(self.value[0],),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "U64": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class U128:
+    discriminator: typing.ClassVar = 5
+    kind: typing.ClassVar = "U128"
+    value: U128Value
+
+    def to_json(self) -> U128JSON:
+        return U128JSON(
+            kind="U128",
+            value=(self.value[0],),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "U128": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class Pubkey:
+    discriminator: typing.ClassVar = 6
+    kind: typing.ClassVar = "Pubkey"
+    value: PubkeyValue
+
+    def to_json(self) -> PubkeyJSON:
+        return PubkeyJSON(
+            kind="Pubkey",
+            value=(str(self.value[0]),),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "Pubkey": {
+                "item_0": self.value[0],
+            },
+        }
+
+
+@dataclass
+class ElevationGroup:
+    discriminator: typing.ClassVar = 7
+    kind: typing.ClassVar = "ElevationGroup"
+    value: ElevationGroupValue
+
+    def to_json(self) -> ElevationGroupJSON:
+        return ElevationGroupJSON(
+            kind="ElevationGroup",
+            value=(self.value[0].to_json(),),
+        )
+
+    def to_encodable(self) -> dict:
+        return {
+            "ElevationGroup": {
+                "item_0": self.value[0].to_encodable(),
+            },
+        }
+
+
+UpdateLendingMarketConfigValueKind = typing.Union[
+    Bool, U8, U8Array, U16, U64, U128, Pubkey, ElevationGroup
+]
+UpdateLendingMarketConfigValueJSON = typing.Union[
+    BoolJSON,
+    U8JSON,
+    U8ArrayJSON,
+    U16JSON,
+    U64JSON,
+    U128JSON,
+    PubkeyJSON,
+    ElevationGroupJSON,
+]
+
+
+def from_decoded(obj: dict) -> UpdateLendingMarketConfigValueKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "Bool" in obj:
+        val = obj["Bool"]
+        return Bool((val["item_0"],))
+    if "U8" in obj:
+        val = obj["U8"]
+        return U8((val["item_0"],))
+    if "U8Array" in obj:
+        val = obj["U8Array"]
+        return U8Array((val["item_0"],))
+    if "U16" in obj:
+        val = obj["U16"]
+        return U16((val["item_0"],))
+    if "U64" in obj:
+        val = obj["U64"]
+        return U64((val["item_0"],))
+    if "U128" in obj:
+        val = obj["U128"]
+        return U128((val["item_0"],))
+    if "Pubkey" in obj:
+        val = obj["Pubkey"]
+        return Pubkey((val["item_0"],))
+    if "ElevationGroup" in obj:
+        val = obj["ElevationGroup"]
+        return ElevationGroup(
+            (elevation_group.ElevationGroup.from_decoded(val["item_0"]),)
+        )
+    raise ValueError("Invalid enum object")
+
+
+def from_json(
+    obj: UpdateLendingMarketConfigValueJSON,
+) -> UpdateLendingMarketConfigValueKind:
+    if obj["kind"] == "Bool":
+        bool_json_value = typing.cast(BoolJSONValue, obj["value"])
+        return Bool((bool_json_value[0],))
+    if obj["kind"] == "U8":
+        u8json_value = typing.cast(U8JSONValue, obj["value"])
+        return U8((u8json_value[0],))
+    if obj["kind"] == "U8Array":
+        u8_array_json_value = typing.cast(U8ArrayJSONValue, obj["value"])
+        return U8Array((u8_array_json_value[0],))
+    if obj["kind"] == "U16":
+        u16json_value = typing.cast(U16JSONValue, obj["value"])
+        return U16((u16json_value[0],))
+    if obj["kind"] == "U64":
+        u64json_value = typing.cast(U64JSONValue, obj["value"])
+        return U64((u64json_value[0],))
+    if obj["kind"] == "U128":
+        u128json_value = typing.cast(U128JSONValue, obj["value"])
+        return U128((u128json_value[0],))
+    if obj["kind"] == "Pubkey":
+        pubkey_json_value = typing.cast(PubkeyJSONValue, obj["value"])
+        return Pubkey((Pubkey.from_string(pubkey_json_value[0]),))
+    if obj["kind"] == "ElevationGroup":
+        elevation_group_json_value = typing.cast(ElevationGroupJSONValue, obj["value"])
+        return ElevationGroup(
+            (elevation_group.ElevationGroup.from_json(elevation_group_json_value[0]),)
+        )
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen(
+    "Bool" / borsh.CStruct("item_0" / borsh.Bool),
+    "U8" / borsh.CStruct("item_0" / borsh.U8),
+    "U8Array" / borsh.CStruct("item_0" / borsh.U8[8]),
+    "U16" / borsh.CStruct("item_0" / borsh.U16),
+    "U64" / borsh.CStruct("item_0" / borsh.U64),
+    "U128" / borsh.CStruct("item_0" / borsh.U128),
+    "Pubkey" / borsh.CStruct("item_0" / BorshPubkey),
+    "ElevationGroup" / borsh.CStruct("item_0" / elevation_group.ElevationGroup.layout),
+)

--- a/codegen_lend/types/update_lending_market_mode.py
+++ b/codegen_lend/types/update_lending_market_mode.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from anchorpy.borsh_extension import EnumForCodegen
+import borsh_construct as borsh
+
+
+class UpdateOwnerJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateOwner"]
+
+
+class UpdateEmergencyModeJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateEmergencyMode"]
+
+
+class UpdateLiquidationCloseFactorJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateLiquidationCloseFactor"]
+
+
+class UpdateLiquidationMaxValueJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateLiquidationMaxValue"]
+
+
+class UpdateGlobalUnhealthyBorrowJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateGlobalUnhealthyBorrow"]
+
+
+class UpdateGlobalAllowedBorrowJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateGlobalAllowedBorrow"]
+
+
+class UpdateRiskCouncilJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateRiskCouncil"]
+
+
+class UpdateMinFullLiquidationThresholdJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMinFullLiquidationThreshold"]
+
+
+class UpdateInsolvencyRiskLtvJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateInsolvencyRiskLtv"]
+
+
+class UpdateElevationGroupJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateElevationGroup"]
+
+
+class UpdateReferralFeeBpsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateReferralFeeBps"]
+
+
+class UpdateMultiplierPointsJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMultiplierPoints"]
+
+
+class UpdatePriceRefreshTriggerToMaxAgePctJSON(typing.TypedDict):
+    kind: typing.Literal["UpdatePriceRefreshTriggerToMaxAgePct"]
+
+
+class UpdateAutodeleverageEnabledJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateAutodeleverageEnabled"]
+
+
+class UpdateBorrowingDisabledJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateBorrowingDisabled"]
+
+
+class UpdateMinNetValueObligationPostActionJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMinNetValueObligationPostAction"]
+
+
+class UpdateMinValueSkipPriorityLiqCheckJSON(typing.TypedDict):
+    kind: typing.Literal["UpdateMinValueSkipPriorityLiqCheck"]
+
+
+@dataclass
+class UpdateOwner:
+    discriminator: typing.ClassVar = 0
+    kind: typing.ClassVar = "UpdateOwner"
+
+    @classmethod
+    def to_json(cls) -> UpdateOwnerJSON:
+        return UpdateOwnerJSON(
+            kind="UpdateOwner",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateOwner": {},
+        }
+
+
+@dataclass
+class UpdateEmergencyMode:
+    discriminator: typing.ClassVar = 1
+    kind: typing.ClassVar = "UpdateEmergencyMode"
+
+    @classmethod
+    def to_json(cls) -> UpdateEmergencyModeJSON:
+        return UpdateEmergencyModeJSON(
+            kind="UpdateEmergencyMode",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateEmergencyMode": {},
+        }
+
+
+@dataclass
+class UpdateLiquidationCloseFactor:
+    discriminator: typing.ClassVar = 2
+    kind: typing.ClassVar = "UpdateLiquidationCloseFactor"
+
+    @classmethod
+    def to_json(cls) -> UpdateLiquidationCloseFactorJSON:
+        return UpdateLiquidationCloseFactorJSON(
+            kind="UpdateLiquidationCloseFactor",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateLiquidationCloseFactor": {},
+        }
+
+
+@dataclass
+class UpdateLiquidationMaxValue:
+    discriminator: typing.ClassVar = 3
+    kind: typing.ClassVar = "UpdateLiquidationMaxValue"
+
+    @classmethod
+    def to_json(cls) -> UpdateLiquidationMaxValueJSON:
+        return UpdateLiquidationMaxValueJSON(
+            kind="UpdateLiquidationMaxValue",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateLiquidationMaxValue": {},
+        }
+
+
+@dataclass
+class UpdateGlobalUnhealthyBorrow:
+    discriminator: typing.ClassVar = 4
+    kind: typing.ClassVar = "UpdateGlobalUnhealthyBorrow"
+
+    @classmethod
+    def to_json(cls) -> UpdateGlobalUnhealthyBorrowJSON:
+        return UpdateGlobalUnhealthyBorrowJSON(
+            kind="UpdateGlobalUnhealthyBorrow",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateGlobalUnhealthyBorrow": {},
+        }
+
+
+@dataclass
+class UpdateGlobalAllowedBorrow:
+    discriminator: typing.ClassVar = 5
+    kind: typing.ClassVar = "UpdateGlobalAllowedBorrow"
+
+    @classmethod
+    def to_json(cls) -> UpdateGlobalAllowedBorrowJSON:
+        return UpdateGlobalAllowedBorrowJSON(
+            kind="UpdateGlobalAllowedBorrow",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateGlobalAllowedBorrow": {},
+        }
+
+
+@dataclass
+class UpdateRiskCouncil:
+    discriminator: typing.ClassVar = 6
+    kind: typing.ClassVar = "UpdateRiskCouncil"
+
+    @classmethod
+    def to_json(cls) -> UpdateRiskCouncilJSON:
+        return UpdateRiskCouncilJSON(
+            kind="UpdateRiskCouncil",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateRiskCouncil": {},
+        }
+
+
+@dataclass
+class UpdateMinFullLiquidationThreshold:
+    discriminator: typing.ClassVar = 7
+    kind: typing.ClassVar = "UpdateMinFullLiquidationThreshold"
+
+    @classmethod
+    def to_json(cls) -> UpdateMinFullLiquidationThresholdJSON:
+        return UpdateMinFullLiquidationThresholdJSON(
+            kind="UpdateMinFullLiquidationThreshold",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMinFullLiquidationThreshold": {},
+        }
+
+
+@dataclass
+class UpdateInsolvencyRiskLtv:
+    discriminator: typing.ClassVar = 8
+    kind: typing.ClassVar = "UpdateInsolvencyRiskLtv"
+
+    @classmethod
+    def to_json(cls) -> UpdateInsolvencyRiskLtvJSON:
+        return UpdateInsolvencyRiskLtvJSON(
+            kind="UpdateInsolvencyRiskLtv",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateInsolvencyRiskLtv": {},
+        }
+
+
+@dataclass
+class UpdateElevationGroup:
+    discriminator: typing.ClassVar = 9
+    kind: typing.ClassVar = "UpdateElevationGroup"
+
+    @classmethod
+    def to_json(cls) -> UpdateElevationGroupJSON:
+        return UpdateElevationGroupJSON(
+            kind="UpdateElevationGroup",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateElevationGroup": {},
+        }
+
+
+@dataclass
+class UpdateReferralFeeBps:
+    discriminator: typing.ClassVar = 10
+    kind: typing.ClassVar = "UpdateReferralFeeBps"
+
+    @classmethod
+    def to_json(cls) -> UpdateReferralFeeBpsJSON:
+        return UpdateReferralFeeBpsJSON(
+            kind="UpdateReferralFeeBps",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateReferralFeeBps": {},
+        }
+
+
+@dataclass
+class UpdateMultiplierPoints:
+    discriminator: typing.ClassVar = 11
+    kind: typing.ClassVar = "UpdateMultiplierPoints"
+
+    @classmethod
+    def to_json(cls) -> UpdateMultiplierPointsJSON:
+        return UpdateMultiplierPointsJSON(
+            kind="UpdateMultiplierPoints",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMultiplierPoints": {},
+        }
+
+
+@dataclass
+class UpdatePriceRefreshTriggerToMaxAgePct:
+    discriminator: typing.ClassVar = 12
+    kind: typing.ClassVar = "UpdatePriceRefreshTriggerToMaxAgePct"
+
+    @classmethod
+    def to_json(cls) -> UpdatePriceRefreshTriggerToMaxAgePctJSON:
+        return UpdatePriceRefreshTriggerToMaxAgePctJSON(
+            kind="UpdatePriceRefreshTriggerToMaxAgePct",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdatePriceRefreshTriggerToMaxAgePct": {},
+        }
+
+
+@dataclass
+class UpdateAutodeleverageEnabled:
+    discriminator: typing.ClassVar = 13
+    kind: typing.ClassVar = "UpdateAutodeleverageEnabled"
+
+    @classmethod
+    def to_json(cls) -> UpdateAutodeleverageEnabledJSON:
+        return UpdateAutodeleverageEnabledJSON(
+            kind="UpdateAutodeleverageEnabled",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateAutodeleverageEnabled": {},
+        }
+
+
+@dataclass
+class UpdateBorrowingDisabled:
+    discriminator: typing.ClassVar = 14
+    kind: typing.ClassVar = "UpdateBorrowingDisabled"
+
+    @classmethod
+    def to_json(cls) -> UpdateBorrowingDisabledJSON:
+        return UpdateBorrowingDisabledJSON(
+            kind="UpdateBorrowingDisabled",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateBorrowingDisabled": {},
+        }
+
+
+@dataclass
+class UpdateMinNetValueObligationPostAction:
+    discriminator: typing.ClassVar = 15
+    kind: typing.ClassVar = "UpdateMinNetValueObligationPostAction"
+
+    @classmethod
+    def to_json(cls) -> UpdateMinNetValueObligationPostActionJSON:
+        return UpdateMinNetValueObligationPostActionJSON(
+            kind="UpdateMinNetValueObligationPostAction",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMinNetValueObligationPostAction": {},
+        }
+
+
+@dataclass
+class UpdateMinValueSkipPriorityLiqCheck:
+    discriminator: typing.ClassVar = 16
+    kind: typing.ClassVar = "UpdateMinValueSkipPriorityLiqCheck"
+
+    @classmethod
+    def to_json(cls) -> UpdateMinValueSkipPriorityLiqCheckJSON:
+        return UpdateMinValueSkipPriorityLiqCheckJSON(
+            kind="UpdateMinValueSkipPriorityLiqCheck",
+        )
+
+    @classmethod
+    def to_encodable(cls) -> dict:
+        return {
+            "UpdateMinValueSkipPriorityLiqCheck": {},
+        }
+
+
+UpdateLendingMarketModeKind = typing.Union[
+    UpdateOwner,
+    UpdateEmergencyMode,
+    UpdateLiquidationCloseFactor,
+    UpdateLiquidationMaxValue,
+    UpdateGlobalUnhealthyBorrow,
+    UpdateGlobalAllowedBorrow,
+    UpdateRiskCouncil,
+    UpdateMinFullLiquidationThreshold,
+    UpdateInsolvencyRiskLtv,
+    UpdateElevationGroup,
+    UpdateReferralFeeBps,
+    UpdateMultiplierPoints,
+    UpdatePriceRefreshTriggerToMaxAgePct,
+    UpdateAutodeleverageEnabled,
+    UpdateBorrowingDisabled,
+    UpdateMinNetValueObligationPostAction,
+    UpdateMinValueSkipPriorityLiqCheck,
+]
+UpdateLendingMarketModeJSON = typing.Union[
+    UpdateOwnerJSON,
+    UpdateEmergencyModeJSON,
+    UpdateLiquidationCloseFactorJSON,
+    UpdateLiquidationMaxValueJSON,
+    UpdateGlobalUnhealthyBorrowJSON,
+    UpdateGlobalAllowedBorrowJSON,
+    UpdateRiskCouncilJSON,
+    UpdateMinFullLiquidationThresholdJSON,
+    UpdateInsolvencyRiskLtvJSON,
+    UpdateElevationGroupJSON,
+    UpdateReferralFeeBpsJSON,
+    UpdateMultiplierPointsJSON,
+    UpdatePriceRefreshTriggerToMaxAgePctJSON,
+    UpdateAutodeleverageEnabledJSON,
+    UpdateBorrowingDisabledJSON,
+    UpdateMinNetValueObligationPostActionJSON,
+    UpdateMinValueSkipPriorityLiqCheckJSON,
+]
+
+
+def from_decoded(obj: dict) -> UpdateLendingMarketModeKind:
+    if not isinstance(obj, dict):
+        raise ValueError("Invalid enum object")
+    if "UpdateOwner" in obj:
+        return UpdateOwner()
+    if "UpdateEmergencyMode" in obj:
+        return UpdateEmergencyMode()
+    if "UpdateLiquidationCloseFactor" in obj:
+        return UpdateLiquidationCloseFactor()
+    if "UpdateLiquidationMaxValue" in obj:
+        return UpdateLiquidationMaxValue()
+    if "UpdateGlobalUnhealthyBorrow" in obj:
+        return UpdateGlobalUnhealthyBorrow()
+    if "UpdateGlobalAllowedBorrow" in obj:
+        return UpdateGlobalAllowedBorrow()
+    if "UpdateRiskCouncil" in obj:
+        return UpdateRiskCouncil()
+    if "UpdateMinFullLiquidationThreshold" in obj:
+        return UpdateMinFullLiquidationThreshold()
+    if "UpdateInsolvencyRiskLtv" in obj:
+        return UpdateInsolvencyRiskLtv()
+    if "UpdateElevationGroup" in obj:
+        return UpdateElevationGroup()
+    if "UpdateReferralFeeBps" in obj:
+        return UpdateReferralFeeBps()
+    if "UpdateMultiplierPoints" in obj:
+        return UpdateMultiplierPoints()
+    if "UpdatePriceRefreshTriggerToMaxAgePct" in obj:
+        return UpdatePriceRefreshTriggerToMaxAgePct()
+    if "UpdateAutodeleverageEnabled" in obj:
+        return UpdateAutodeleverageEnabled()
+    if "UpdateBorrowingDisabled" in obj:
+        return UpdateBorrowingDisabled()
+    if "UpdateMinNetValueObligationPostAction" in obj:
+        return UpdateMinNetValueObligationPostAction()
+    if "UpdateMinValueSkipPriorityLiqCheck" in obj:
+        return UpdateMinValueSkipPriorityLiqCheck()
+    raise ValueError("Invalid enum object")
+
+
+def from_json(obj: UpdateLendingMarketModeJSON) -> UpdateLendingMarketModeKind:
+    if obj["kind"] == "UpdateOwner":
+        return UpdateOwner()
+    if obj["kind"] == "UpdateEmergencyMode":
+        return UpdateEmergencyMode()
+    if obj["kind"] == "UpdateLiquidationCloseFactor":
+        return UpdateLiquidationCloseFactor()
+    if obj["kind"] == "UpdateLiquidationMaxValue":
+        return UpdateLiquidationMaxValue()
+    if obj["kind"] == "UpdateGlobalUnhealthyBorrow":
+        return UpdateGlobalUnhealthyBorrow()
+    if obj["kind"] == "UpdateGlobalAllowedBorrow":
+        return UpdateGlobalAllowedBorrow()
+    if obj["kind"] == "UpdateRiskCouncil":
+        return UpdateRiskCouncil()
+    if obj["kind"] == "UpdateMinFullLiquidationThreshold":
+        return UpdateMinFullLiquidationThreshold()
+    if obj["kind"] == "UpdateInsolvencyRiskLtv":
+        return UpdateInsolvencyRiskLtv()
+    if obj["kind"] == "UpdateElevationGroup":
+        return UpdateElevationGroup()
+    if obj["kind"] == "UpdateReferralFeeBps":
+        return UpdateReferralFeeBps()
+    if obj["kind"] == "UpdateMultiplierPoints":
+        return UpdateMultiplierPoints()
+    if obj["kind"] == "UpdatePriceRefreshTriggerToMaxAgePct":
+        return UpdatePriceRefreshTriggerToMaxAgePct()
+    if obj["kind"] == "UpdateAutodeleverageEnabled":
+        return UpdateAutodeleverageEnabled()
+    if obj["kind"] == "UpdateBorrowingDisabled":
+        return UpdateBorrowingDisabled()
+    if obj["kind"] == "UpdateMinNetValueObligationPostAction":
+        return UpdateMinNetValueObligationPostAction()
+    if obj["kind"] == "UpdateMinValueSkipPriorityLiqCheck":
+        return UpdateMinValueSkipPriorityLiqCheck()
+    kind = obj["kind"]
+    raise ValueError(f"Unrecognized enum kind: {kind}")
+
+
+layout = EnumForCodegen(
+    "UpdateOwner" / borsh.CStruct(),
+    "UpdateEmergencyMode" / borsh.CStruct(),
+    "UpdateLiquidationCloseFactor" / borsh.CStruct(),
+    "UpdateLiquidationMaxValue" / borsh.CStruct(),
+    "UpdateGlobalUnhealthyBorrow" / borsh.CStruct(),
+    "UpdateGlobalAllowedBorrow" / borsh.CStruct(),
+    "UpdateRiskCouncil" / borsh.CStruct(),
+    "UpdateMinFullLiquidationThreshold" / borsh.CStruct(),
+    "UpdateInsolvencyRiskLtv" / borsh.CStruct(),
+    "UpdateElevationGroup" / borsh.CStruct(),
+    "UpdateReferralFeeBps" / borsh.CStruct(),
+    "UpdateMultiplierPoints" / borsh.CStruct(),
+    "UpdatePriceRefreshTriggerToMaxAgePct" / borsh.CStruct(),
+    "UpdateAutodeleverageEnabled" / borsh.CStruct(),
+    "UpdateBorrowingDisabled" / borsh.CStruct(),
+    "UpdateMinNetValueObligationPostAction" / borsh.CStruct(),
+    "UpdateMinValueSkipPriorityLiqCheck" / borsh.CStruct(),
+)

--- a/codegen_lend/types/withdrawal_caps.py
+++ b/codegen_lend/types/withdrawal_caps.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import typing
+from dataclasses import dataclass
+from construct import Container
+import borsh_construct as borsh
+
+
+class WithdrawalCapsJSON(typing.TypedDict):
+    config_capacity: int
+    current_total: int
+    last_interval_start_timestamp: int
+    config_interval_length_seconds: int
+
+
+@dataclass
+class WithdrawalCaps:
+    layout: typing.ClassVar = borsh.CStruct(
+        "config_capacity" / borsh.I64,
+        "current_total" / borsh.I64,
+        "last_interval_start_timestamp" / borsh.U64,
+        "config_interval_length_seconds" / borsh.U64,
+    )
+    config_capacity: int
+    current_total: int
+    last_interval_start_timestamp: int
+    config_interval_length_seconds: int
+
+    @classmethod
+    def from_decoded(cls, obj: Container) -> "WithdrawalCaps":
+        return cls(
+            config_capacity=obj.config_capacity,
+            current_total=obj.current_total,
+            last_interval_start_timestamp=obj.last_interval_start_timestamp,
+            config_interval_length_seconds=obj.config_interval_length_seconds,
+        )
+
+    def to_encodable(self) -> dict[str, typing.Any]:
+        return {
+            "config_capacity": self.config_capacity,
+            "current_total": self.current_total,
+            "last_interval_start_timestamp": self.last_interval_start_timestamp,
+            "config_interval_length_seconds": self.config_interval_length_seconds,
+        }
+
+    def to_json(self) -> WithdrawalCapsJSON:
+        return {
+            "config_capacity": self.config_capacity,
+            "current_total": self.current_total,
+            "last_interval_start_timestamp": self.last_interval_start_timestamp,
+            "config_interval_length_seconds": self.config_interval_length_seconds,
+        }
+
+    @classmethod
+    def from_json(cls, obj: WithdrawalCapsJSON) -> "WithdrawalCaps":
+        return cls(
+            config_capacity=obj["config_capacity"],
+            current_total=obj["current_total"],
+            last_interval_start_timestamp=obj["last_interval_start_timestamp"],
+            config_interval_length_seconds=obj["config_interval_length_seconds"],
+        )

--- a/external_klend_fetch_data.ipynb
+++ b/external_klend_fetch_data.ipynb
@@ -33,7 +33,8 @@
    "source": [
     "from external_klend_utils import *\n",
     "import time\n",
-    "import os"
+    "import os\n",
+    "from pprint import pprint"
    ]
   },
   {
@@ -46,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 4,
    "id": "c3998c0f-06a1-4fbe-9713-5b882d7a7f13",
    "metadata": {
     "tags": []
@@ -71,48 +72,690 @@
     "    print(f\"Number of reserves = {len(reserves_configs)}\")\n",
     "    print(f\"Number of elevation groups = {len(elevation_group_dict)}\")\n",
     "    print(f\"Number of loans = {loan_metrics_df.shape[0]:,}\")\n",
-    "    return reserves_configs, elevation_group_dict,loan_metrics_df"
+    "    return reserves_configs, elevation_group_dict,loan_metrics_df\n",
+    "\n",
+    "\n",
+    "    \n",
+    "uri = os.getenv(\"SOLANARPC_HTTP_URI\")\n",
+    "# make kamino_lend_program\n",
+    "kamino_lend_program = get_kamino_lend_program(uri)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a50659e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obligations = await get_all_obligations(\n",
+    "    kamino_lend_program,\n",
+    "    LENDING_MARKETS[\"ethena_market\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a655d20",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "71dcbc07",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "inside\n"
+     ]
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "1c091a77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def object_to_dict(obj):\n",
+    "    \"\"\"\n",
+    "    Exploding objects\n",
+    "    \"\"\"\n",
+    "    print(\"inside\")\n",
+    "    if isinstance(obj, list):\n",
+    "        print(\"here\")\n",
+    "        return [object_to_dict(item) for item in obj]\n",
+    "    elif hasattr(obj, \"__dict__\"):\n",
+    "        result = {}\n",
+    "        for key, val in obj.__dict__.items():\n",
+    "            # Fixing this to not contain all of the padded values\n",
+    "            # some padding starts with padding others are config_padding etc\n",
+    "            print(f\"key: {key}\")\n",
+    "            if \"padding\" in str(key):\n",
+    "                print(\"skipping\")\n",
+    "                continue\n",
+    "            element = []\n",
+    "            if isinstance(val, list):\n",
+    "                print(\"not skipping\")\n",
+    "                for item in val:\n",
+    "                    if hasattr(item, \"__dict__\"):\n",
+    "                        element.append(object_to_dict(item))\n",
+    "                    else:\n",
+    "                        element.append(item)\n",
+    "                result[key] = element\n",
+    "            else:\n",
+    "                if hasattr(val, \"__dict__\"):\n",
+    "                    result[key] = object_to_dict(val)\n",
+    "                else:\n",
+    "                    result[key] = val\n",
+    "        return result\n",
+    "    else:\n",
+    "        return obj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "7971a026",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "inside\n"
+     ]
+    }
+   ],
+   "source": [
+    "dict = object_to_dict(obligations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfffb980",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dic[Pubkey.from_string(\"Hgd2j52r71SFDyHZB3DjMPccb31yc3wes7JbUaGpQxBi\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "166460a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kamino_client = KaminoClient(os.getenv(\"SOLANARPC_HTTP_URI\"))\n",
+    "lending_market_object = await kamino_client.fetch_with_retries(\n",
+    "    LendingMarket.fetch, Pubkey.from_string(\"BJnbcRHqvppTyGesLzWASGKnmnF1wq9jZu6ExrjT7wvF\"), extra=None\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b4fa38e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lending_market_object.elevation_groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d24ca7ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uri = os.getenv(\"SOLANARPC_HTTP_URI\")\n",
+    "# make kamino_lend_program\n",
+    "kamino_lend_program = get_kamino_lend_program(uri)\n",
+    "\n",
+    "elevation = await get_elevation_group_dict( \"7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c2040e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1384f1d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e2dc002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reserves_configs = await get_reserves_configs(kamino_lend_program, \"7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51ee462b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e0822f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reserves_configs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3edf3d90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reserves_configs['EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v']['account']['config']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4145e6f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation"
    ]
   },
   {
    "cell_type": "raw",
    "id": "5ae4db6e-10ab-4930-b844-6ac4bf2298eb",
-   "metadata": {},
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
    "source": [
     "# see external_klend_utils.py\n",
     "# LENDING_MARKETS = {\n",
     "#     \"main_market\": \"7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF\",\n",
     "#     \"jlp_market\": \"DxXdAyU3kCjnyggvHmY5nAwg5cRbbmdyX3npfDMjjMek\",\n",
     "#     \"altcoin_market\": \"ByYiZxp8QrdN9qbdtaAiePN8AAr3qvTPppNJDpf5DVJ5\",\n",
+    "#     \"ethena_market\": \"BJnbcRHqvppTyGesLzWASGKnmnF1wq9jZu6ExrjT7wvF\"\n",
     "# }"
    ]
   },
   {
+   "cell_type": "raw",
+   "id": "0e6ed8c6",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "main_market_addr = \"7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "bd9fffe6",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "reserves_configs"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "439466e5",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "reserves_configs"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "0d21af8a",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": []
+  },
+  {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "33f657db-9154-4e54-8dfa-1350658f5ede",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of reserves = 14\n",
-      "Number of elevation groups = 0\n",
-      "Number of loans = 22,093\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "lending_market = LENDING_MARKETS['altcoin_market']\n",
+    "lending_market = LENDING_MARKETS['ethena_market']\n",
     "reserves_configs, elevation_group_dict,loan_metrics_df = await get_all_market_data(lending_market)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "id": "081ce48b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x in loan_metrics_df.keys():\n",
+    "    print(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c01d90a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "main_market_addr = \"7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f430d14c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation_groups = await get_elevation_group_dict(LENDING_MARKETS['main_market'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77275850",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LENDING_MARKETS['main_market']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a5c3251",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation_groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42433068",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reserves_configs['J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn']['account']['config']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abed534e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kamino_client = KaminoClient(os.getenv(\"SOLANARPC_HTTP_URI\"))\n",
+    "lending_market_object = await kamino_client.fetch_with_retries(\n",
+    "    LendingMarket.fetch, Pubkey.from_string(LENDING_MARKETS['main_market']), extra=None\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ae541c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Pubkey"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4f7991c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await LendingMarket.fetch(client, Pubkey.from_string(main_market_addr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19f4b1ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "    \n",
+    "uri = os.getenv(\"SOLANARPC_HTTP_URI\")\n",
+    "# make kamino_lend_program\n",
+    "kamino_lend_program = get_kamino_lend_program(uri)\n",
+    "\n",
+    "reserves = await get_reserves_configs(kamino_lend_program, main_market_addr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d43bee3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "uri = os.getenv(\"SOLANARPC_HTTP_URI\")\n",
+    "\n",
+    "    # make kamino_lend_program\n",
+    "kamino_lend_program = get_kamino_lend_program(uri)\n",
+    "reserves_configs = await get_reserves_configs(kamino_lend_program, \"7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32eb4ecf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(reserves_configs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a5220f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await kamino_lend_program.account[\"Reserve\"].all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72503745",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obligations = await kamino_lend_program.account[\"Obligation\"].all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e6269a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(obligations[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65624efc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lending_markets = await kamino_lend_program.account[\"LendingMarket\"].all(\n",
+    "    filters = []\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5e1b5f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = AsyncClient(os.getenv(\"SOLANARPC_HTTP_URI\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72f13456",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = await client.get_account_info_json_parsed(\n",
+    "    Pubkey.from_string(\"Hy2S5arXGFgsvze47PCgSjF92ZQCiAfUJnFkqZQMXu4T\")\n",
+    ")\n",
+    "dec = Reserve.layout.parse(data.value.data[ACCOUNT_DISCRIMINATOR_SIZE:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d20c0e07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dec.config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f79633d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = json.loads(data.to_json())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c05e280",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dec = LendingMarket.layout.parse(data.value.data[ACCOUNT_DISCRIMINATOR_SIZE:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d9c468c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc67e3bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "decoded_bytes = base64.b64decode(data['result']['value']['data'][0])\n",
+    "fir_8 = decoded_bytes[:8]\n",
+    "rep = fir_8.hex()\n",
+    "print(rep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ee5d4c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bytes.fromhex(rep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6182c74b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(rep)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0141fb24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bytes.fromhex(\"5ae6f30c297b461d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f38aec42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Reserve.discriminator.hex()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ef72665",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['result']['value']['data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6512885f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reserves = await kamino_lend_program.account[\"Reserve\"].all(\n",
+    "    filters = [RESERVE_SIZE, MemcmpOpts(0, Reserve.discriminator)]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17444338",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6939666",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Reserve.discriminator.hex()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa6ff103",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Obligation.discriminator.hex()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c699f8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation_groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d3b187e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pprint import pprint as print\n",
+    "print('')\n",
+    "#\n",
+    "print(reserves_configs['J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn']['account']['config'].keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2566042",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elevation_groups"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e206934a-0f05-4062-a255-d25913b9d5bd",
    "metadata": {
     "tags": []
@@ -124,34 +767,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "ae8ce125-2efa-441a-ab8f-3692c5a126e5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['DRIFT',\n",
-       " 'KMNO',\n",
-       " 'PRCL',\n",
-       " 'USDH',\n",
-       " 'INF',\n",
-       " 'TNSR',\n",
-       " 'USDC',\n",
-       " 'BONK',\n",
-       " 'W',\n",
-       " 'JTO',\n",
-       " 'WEN',\n",
-       " 'PYTH',\n",
-       " 'WIF',\n",
-       " 'JUP']"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# token reserve tickers in this market\n",
     "[mint_to_str_map[k] for k in reserves_configs.keys()]"
@@ -159,33 +778,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "d99a3caf-3515-46da-8e17-20300746775f",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['USDH',\n",
-       " 'INF',\n",
-       " 'TNSR',\n",
-       " 'USDC',\n",
-       " 'BONK',\n",
-       " 'W',\n",
-       " 'JTO',\n",
-       " 'WEN',\n",
-       " 'PYTH',\n",
-       " 'WIF',\n",
-       " 'JUP']"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# token reserve tickers in this market which are shown in UI (status == 0)\n",
     "reserves_configs_keys_ui = {\n",
@@ -199,168 +797,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a12ea88d-a16d-46b0-b39e-3f7e49398c91",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>owner</th>\n",
-       "      <th>elevation_group</th>\n",
-       "      <th>current_ltv</th>\n",
-       "      <th>max_ltv</th>\n",
-       "      <th>unhealthy_ltv</th>\n",
-       "      <th>dist_to_liq</th>\n",
-       "      <th>total_deposit_usd</th>\n",
-       "      <th>total_borrow_usd</th>\n",
-       "      <th>net_value</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>public_key</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>4aALVBGvh2czH4rLteMY3CFaHf461bMcv1pmiFBHvqVE</th>\n",
-       "      <td>CbQGxnGEdfBK6BsPBB3so3PVRuRFx2oDaDupGfuYhBvA</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.148684</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.20</td>\n",
-       "      <td>0.051316</td>\n",
-       "      <td>1.992942e+01</td>\n",
-       "      <td>0.592638</td>\n",
-       "      <td>1.933678e+01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>EjcKFuHJtq3CraQjvo3CXNcwf2PtNZKxaeUiRQMVYhNg</th>\n",
-       "      <td>Hrix7ZDGtBFsVLUAGQiXSYT3aTb3CBLLfAjtgfHtCqiF</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.678291</td>\n",
-       "      <td>0.65</td>\n",
-       "      <td>0.75</td>\n",
-       "      <td>0.071709</td>\n",
-       "      <td>2.018593e-01</td>\n",
-       "      <td>0.136919</td>\n",
-       "      <td>6.494001e-02</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8rRg3ftQjfN3vFzERQwvZ3Rnv4sgY7jva4ZhMYPMHr2j</th>\n",
-       "      <td>337tAvLe7hgoeu2FC3yLHpnqyr2RajhnDVtjEMes9YfJ</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.127842</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.20</td>\n",
-       "      <td>0.072158</td>\n",
-       "      <td>8.378420e+04</td>\n",
-       "      <td>10711.114674</td>\n",
-       "      <td>7.307308e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2xJdmVFRecZ9FhDzHs3GKHDY5qT6tNeswfDcgCb34Ghq</th>\n",
-       "      <td>H7mtTUY1KNcAM9ZPUL9hYsB3z4z2g67QdtX3wdsASc4v</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.127270</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.20</td>\n",
-       "      <td>0.072730</td>\n",
-       "      <td>1.339238e+06</td>\n",
-       "      <td>170445.482716</td>\n",
-       "      <td>1.168793e+06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Dric7ceWrTktdxoosvwXJBRTUnAxVgt489RvKB76txkU</th>\n",
-       "      <td>A1HcDsVATuWg9JHuJXsc6oi66hBnLHyFS8YmDrAAdnv4</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0.126935</td>\n",
-       "      <td>0.10</td>\n",
-       "      <td>0.20</td>\n",
-       "      <td>0.073065</td>\n",
-       "      <td>7.050872e+04</td>\n",
-       "      <td>8941.547379</td>\n",
-       "      <td>6.150033e+04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                                                     owner  \\\n",
-       "public_key                                                                                   \n",
-       "4aALVBGvh2czH4rLteMY3CFaHf461bMcv1pmiFBHvqVE  CbQGxnGEdfBK6BsPBB3so3PVRuRFx2oDaDupGfuYhBvA   \n",
-       "EjcKFuHJtq3CraQjvo3CXNcwf2PtNZKxaeUiRQMVYhNg  Hrix7ZDGtBFsVLUAGQiXSYT3aTb3CBLLfAjtgfHtCqiF   \n",
-       "8rRg3ftQjfN3vFzERQwvZ3Rnv4sgY7jva4ZhMYPMHr2j  337tAvLe7hgoeu2FC3yLHpnqyr2RajhnDVtjEMes9YfJ   \n",
-       "2xJdmVFRecZ9FhDzHs3GKHDY5qT6tNeswfDcgCb34Ghq  H7mtTUY1KNcAM9ZPUL9hYsB3z4z2g67QdtX3wdsASc4v   \n",
-       "Dric7ceWrTktdxoosvwXJBRTUnAxVgt489RvKB76txkU  A1HcDsVATuWg9JHuJXsc6oi66hBnLHyFS8YmDrAAdnv4   \n",
-       "\n",
-       "                                              elevation_group  current_ltv  \\\n",
-       "public_key                                                                   \n",
-       "4aALVBGvh2czH4rLteMY3CFaHf461bMcv1pmiFBHvqVE                0     0.148684   \n",
-       "EjcKFuHJtq3CraQjvo3CXNcwf2PtNZKxaeUiRQMVYhNg                0     0.678291   \n",
-       "8rRg3ftQjfN3vFzERQwvZ3Rnv4sgY7jva4ZhMYPMHr2j                0     0.127842   \n",
-       "2xJdmVFRecZ9FhDzHs3GKHDY5qT6tNeswfDcgCb34Ghq                0     0.127270   \n",
-       "Dric7ceWrTktdxoosvwXJBRTUnAxVgt489RvKB76txkU                0     0.126935   \n",
-       "\n",
-       "                                              max_ltv  unhealthy_ltv  \\\n",
-       "public_key                                                             \n",
-       "4aALVBGvh2czH4rLteMY3CFaHf461bMcv1pmiFBHvqVE     0.10           0.20   \n",
-       "EjcKFuHJtq3CraQjvo3CXNcwf2PtNZKxaeUiRQMVYhNg     0.65           0.75   \n",
-       "8rRg3ftQjfN3vFzERQwvZ3Rnv4sgY7jva4ZhMYPMHr2j     0.10           0.20   \n",
-       "2xJdmVFRecZ9FhDzHs3GKHDY5qT6tNeswfDcgCb34Ghq     0.10           0.20   \n",
-       "Dric7ceWrTktdxoosvwXJBRTUnAxVgt489RvKB76txkU     0.10           0.20   \n",
-       "\n",
-       "                                              dist_to_liq  total_deposit_usd  \\\n",
-       "public_key                                                                     \n",
-       "4aALVBGvh2czH4rLteMY3CFaHf461bMcv1pmiFBHvqVE     0.051316       1.992942e+01   \n",
-       "EjcKFuHJtq3CraQjvo3CXNcwf2PtNZKxaeUiRQMVYhNg     0.071709       2.018593e-01   \n",
-       "8rRg3ftQjfN3vFzERQwvZ3Rnv4sgY7jva4ZhMYPMHr2j     0.072158       8.378420e+04   \n",
-       "2xJdmVFRecZ9FhDzHs3GKHDY5qT6tNeswfDcgCb34Ghq     0.072730       1.339238e+06   \n",
-       "Dric7ceWrTktdxoosvwXJBRTUnAxVgt489RvKB76txkU     0.073065       7.050872e+04   \n",
-       "\n",
-       "                                              total_borrow_usd     net_value  \n",
-       "public_key                                                                    \n",
-       "4aALVBGvh2czH4rLteMY3CFaHf461bMcv1pmiFBHvqVE          0.592638  1.933678e+01  \n",
-       "EjcKFuHJtq3CraQjvo3CXNcwf2PtNZKxaeUiRQMVYhNg          0.136919  6.494001e-02  \n",
-       "8rRg3ftQjfN3vFzERQwvZ3Rnv4sgY7jva4ZhMYPMHr2j      10711.114674  7.307308e+04  \n",
-       "2xJdmVFRecZ9FhDzHs3GKHDY5qT6tNeswfDcgCb34Ghq     170445.482716  1.168793e+06  \n",
-       "Dric7ceWrTktdxoosvwXJBRTUnAxVgt489RvKB76txkU       8941.547379  6.150033e+04  "
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# view key cols\n",
     "loan_metrics_df_copy = loan_metrics_df.copy()\n",
@@ -383,23 +825,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "35341b62-814e-4301-bd6e-9aa36d531aab",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['DriFtupJYLTosbwoN8koMbEYSx54aFAVLddWsbksjwg7', 'KMNo3nJsBXfcpJTVhZcXLW7RmTwTt4GVFE7suUBo9sS', '4LLbsb5ReP3yEtYzmXewyGjcir5uXtKFURtaEUVC2AHs', 'USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX', '5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm', 'TNSRxcUxoT9xBG3de7PiJyTDYu7kskLqcpddxnEJAS6', 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263', '85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ', 'jtojtomepa8beP8AuQc6eXt5FriJwfFMwQx2v2f9mCL', 'WENWENvqqNya429ubCdR81ZmD69brwQaaBYY6p3LCpk', 'HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3', 'EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm', 'JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN'])"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# get IR curves\n",
     "interest_rates = {}\n",
@@ -427,94 +858,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "dd6724ec-8217-47b9-8059-cc857179e56e",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>utilization_rate</th>\n",
-       "      <th>borrow_rate</th>\n",
-       "      <th>supply_rate</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>85.0</td>\n",
-       "      <td>50.0</td>\n",
-       "      <td>34.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>90.0</td>\n",
-       "      <td>75.0</td>\n",
-       "      <td>54.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>92.0</td>\n",
-       "      <td>100.0</td>\n",
-       "      <td>73.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>95.0</td>\n",
-       "      <td>150.0</td>\n",
-       "      <td>114.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>100.0</td>\n",
-       "      <td>250.0</td>\n",
-       "      <td>200.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   utilization_rate  borrow_rate  supply_rate\n",
-       "0               0.0          0.0          0.0\n",
-       "1              85.0         50.0         34.0\n",
-       "2              90.0         75.0         54.0\n",
-       "3              92.0        100.0         73.6\n",
-       "4              95.0        150.0        114.0\n",
-       "5             100.0        250.0        200.0"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "interest_rates['EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v']['borrow_curve_df']"
    ]
@@ -544,7 +893,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/external_klend_utils.py
+++ b/external_klend_utils.py
@@ -4,7 +4,18 @@ from solders.pubkey import Pubkey
 from anchorpy import Program, Provider, Wallet, Idl
 from dataclasses import dataclass
 from based58 import b58encode
-from typing import Any, Dict, List, Optional, TypedDict, Union, Callable, Any, Coroutine, Sequence
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    TypedDict,
+    Union,
+    Callable,
+    Any,
+    Coroutine,
+    Sequence,
+)
 import os
 import requests, json, datetime, logging
 from requests.exceptions import RequestException
@@ -34,7 +45,7 @@ OBLIGATION_SIZE = Obligation.layout.sizeof() + DISCRIMINATOR_SIZE  # 3344
 SCALE_FACTOR_60 = 2**60
 LAMPORTS_MULTIPLIER = 10**-9
 
-SLOTS_PER_SECOND = 1000 / 450 # approx 450ms per epoch
+SLOTS_PER_SECOND = 1000 / 450  # approx 450ms per epoch
 SLOTS_PER_MINUTE = SLOTS_PER_SECOND * 60
 SLOTS_PER_HOUR = SLOTS_PER_MINUTE * 60
 SLOTS_PER_DAY = SLOTS_PER_HOUR * 24
@@ -71,9 +82,7 @@ def get_kamino_lend_program(uri):
     provider = Provider(client, wallet)
     idl_filename = "kamino_lending.json"
     if os.path.isfile(f"./{idl_filename}"):
-        idl = Idl.from_json(
-            Path(f"./{idl_filename}").open().read()
-        )
+        idl = Idl.from_json(Path(f"./{idl_filename}").open().read())
     else:
         raise BaseException("IDL json file not found!")
     kamino_lend_program = Program(idl, KAMINOLEND_PROGRAM_ID, provider)
@@ -104,8 +113,8 @@ def object_to_dict(obj):
         return result
     else:
         return obj
-    
-    
+
+
 def get_str_from_byte_list(byte_list):
     byte_data = bytes(byte_list)
     # Decode bytes to string
@@ -237,8 +246,8 @@ async def get_loans_metrics(
         return obl_df5, obl_df, obl_df2, obl_df3, obl_df4
     else:
         return obl_df5
-    
-    
+
+
 def get_reserve_mint_decimals_map(reserves_configs):
     reserve_mint_decimals_map = {}
     for reserve_mint, reserve_config in reserves_configs.items():
@@ -476,6 +485,7 @@ def get_borrow_cumulative_borrow_rate(cumulative_borrow_rate_bsf):
         acc_sf += value
     return acc_sf / 2**60
 
+
 def get_token_reserve_to_token_mint_map(reserves_configs):
     return {
         str(reserves_configs[token_mint]["public_key"]): token_mint
@@ -518,6 +528,7 @@ def check_for_dup_borrows_deposits_keys_in_list(obl_df_in):
         borrows_duplicate_keys = find_duplicate_keys(obl_df2.iloc[i].borrows_list)
         if borrows_duplicate_keys:
             raise ValueError(f"borrows_duplicate_keys = {borrows_duplicate_keys}")
+
 
 def merge_dicts(lst):
     merged_dict = {}
@@ -853,6 +864,7 @@ def get_deposit_borrow_token_amount_cols(loan_metrics_df):
 
 # IR CURVES
 
+
 def get_ir_curve(reserves_configs, token):
     borrow_curve_df = pd.DataFrame(
         reserves_configs[token]["account"]["config"]["borrow_rate_curve"]["points"]
@@ -1063,12 +1075,6 @@ def get_curr_util(reserve_config):
     )
 
     return 100 * numerator / denominator if denominator else None
-
-
-
-
-
-
 
 
 # SCOPE DATA FETCHING

--- a/kamino_client/client.py
+++ b/kamino_client/client.py
@@ -65,4 +65,3 @@ class KaminoClient:
             extra,
         )
         return None
-    

--- a/kamino_lending.json
+++ b/kamino_lending.json
@@ -1,3907 +1,4403 @@
 {
-  "version": "0.1.0",
-  "name": "kamino_lending",
-  "instructions": [
-    {
-      "name": "initLendingMarket",
-      "accounts": [
-        {
-          "name": "lendingMarketOwner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "quoteCurrency",
-          "type": {
-            "array": [
-              "u8",
-              32
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateLendingMarket",
-      "accounts": [
-        {
-          "name": "lendingMarketOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "mode",
-          "type": "u64"
-        },
-        {
-          "name": "value",
-          "type": {
-            "array": [
-              "u8",
-              72
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "updateLendingMarketOwner",
-      "accounts": [
-        {
-          "name": "lendingMarketOwnerCached",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initReserve",
-      "accounts": [
-        {
-          "name": "lendingMarketOwner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquidityMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveCollateralMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveCollateralSupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initFarmsForReserve",
-      "accounts": [
-        {
-          "name": "lendingMarketOwner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "farmsProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "farmsGlobalConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "farmState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "farmsVaultAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "mode",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "updateReserveConfig",
-      "accounts": [
-        {
-          "name": "lendingMarketOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "mode",
-          "type": "u64"
-        },
-        {
-          "name": "value",
-          "type": {
-            "array": [
-              "u8",
-              648
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "refreshReserve",
-      "accounts": [
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "pythOracle",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "switchboardPriceOracle",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "switchboardTwapOracle",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "scopePrices",
-          "isMut": false,
-          "isSigner": false,
-          "isOptional": true
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "depositReserveLiquidity",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveCollateralMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "redeemReserveCollateral",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveCollateralMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "collateralAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "initObligation",
-      "accounts": [
-        {
-          "name": "obligationOwner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "seed1Account",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "seed2Account",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "ownerUserMetadata",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "args",
-          "type": {
-            "defined": "InitObligationArgs"
-          }
-        }
-      ]
-    },
-    {
-      "name": "initObligationFarmsForReserve",
-      "accounts": [
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveFarmState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "obligationFarm",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "farmsProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "mode",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "refreshObligationFarmsForReserve",
-      "accounts": [
-        {
-          "name": "crank",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveFarmState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "obligationFarmUserState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "farmsProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "mode",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "refreshObligation",
-      "accounts": [
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "depositObligationCollateral",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "depositReserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveDestinationCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "collateralAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "withdrawObligationCollateral",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserve",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserveSourceCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "collateralAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "borrowObligationLiquidity",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "borrowReserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "borrowReserveLiquidityFeeReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "referrerTokenState",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "repayObligationLiquidity",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "repayReserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "depositReserveLiquidityAndObligationCollateral",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveCollateralMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveDestinationDepositCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "withdrawObligationCollateralAndRedeemReserveCollateral",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveSourceCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveCollateralMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "collateralAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "liquidateObligationAndRedeemReserveCollateral",
-      "accounts": [
-        {
-          "name": "liquidator",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "repayReserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "repayReserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserveCollateralMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserveCollateralSupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserveLiquiditySupply",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "withdrawReserveLiquidityFeeReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationCollateral",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        },
-        {
-          "name": "minAcceptableReceivedCollateralAmount",
-          "type": "u64"
-        },
-        {
-          "name": "maxAllowedLtvOverridePercent",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "redeemFees",
-      "accounts": [
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquidityFeeReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveSupplyLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "flashRepayReserveLiquidity",
-      "accounts": [
-        {
-          "name": "userTransferAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquidityFeeReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "referrerTokenState",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "referrerAccount",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "sysvarInfo",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        },
-        {
-          "name": "borrowInstructionIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "flashBorrowReserveLiquidity",
-      "accounts": [
-        {
-          "name": "userTransferAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveSourceLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "userDestinationLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveLiquidityFeeReceiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "referrerTokenState",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "referrerAccount",
-          "isMut": true,
-          "isSigner": false,
-          "isOptional": true
-        },
-        {
-          "name": "sysvarInfo",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "socializeLoss",
-      "accounts": [
-        {
-          "name": "riskCouncil",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "instructionSysvarAccount",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "requestElevationGroup",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "obligation",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "elevationGroup",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "initReferrerTokenState",
-      "accounts": [
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "referrerTokenState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "referrer",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "initUserMetadata",
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "userMetadata",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "referrer",
-          "type": "publicKey"
-        },
-        {
-          "name": "userLookupTable",
-          "type": "publicKey"
-        }
-      ]
-    },
-    {
-      "name": "withdrawReferrerFees",
-      "accounts": [
-        {
-          "name": "referrer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "referrerTokenState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "reserveSupplyLiquidity",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "referrerTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "withdrawProtocolFee",
-      "accounts": [
-        {
-          "name": "lendingMarketOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "lendingMarket",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "reserve",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketAuthority",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lendingMarketOwnerAta",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "initReferrerStateAndShortUrl",
-      "accounts": [
-        {
-          "name": "referrer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "referrerState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "referrerShortUrl",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "shortUrl",
-          "type": "string"
-        }
-      ]
-    },
-    {
-      "name": "deleteReferrerStateAndShortUrl",
-      "accounts": [
-        {
-          "name": "referrer",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "referrerState",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "shortUrl",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    }
-  ],
-  "accounts": [
-    {
-      "name": "LendingMarket",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "version",
-            "docs": [
-              "Version of lending market"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "bumpSeed",
-            "docs": [
-              "Bump seed for derived authority address"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "lendingMarketOwner",
-            "docs": [
-              "Owner authority which can add new reserves"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "lendingMarketOwnerCached",
-            "docs": [
-              "Temporary cache of the lending market owner, used in update_lending_market_owner"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "quoteCurrency",
-            "docs": [
-              "Currency market prices are quoted in",
-              "e.g. \"USD\" null padded (`*b\"USD\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\"`) or a SPL token mint pubkey"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "referralFeeBps",
-            "docs": [
-              "Referral fee for the lending market, as bps out of the total protocol fee"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "emergencyMode",
-            "type": "u8"
-          },
-          {
-            "name": "reserved",
-            "docs": [
-              "Padding used for alignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "priceRefreshTriggerToMaxAgePct",
-            "docs": [
-              "Refresh price from oracle only if it's older than this percentage of the price max age.",
-              "e.g. if the max age is set to 100s and this is set to 80%, the price will be refreshed if it's older than 80s.",
-              "Price is always refreshed if this set to 0."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "liquidationMaxDebtCloseFactorPct",
-            "docs": [
-              "Percentage of the total borrowed value in an obligation available for liquidation"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "insolvencyRiskUnhealthyLtvPct",
-            "docs": [
-              "Minimum acceptable unhealthy LTV before max_debt_close_factor_pct becomes 100%"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "minFullLiquidationAmountThreshold",
-            "docs": [
-              "Minimum liquidation amount threshold triggering full liquidation for an obligation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "maxLiquidatableDebtMarketValueAtOnce",
-            "docs": [
-              "Max allowed liquidation value in one ix call"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "globalUnhealthyBorrowValue",
-            "docs": [
-              "Global maximum unhealthy borrow value allowed for any obligation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "globalAllowedBorrowValue",
-            "docs": [
-              "Global maximum allowed borrow value allowed for any obligation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "riskCouncil",
-            "docs": [
-              "The address of the risk council, in charge of making parameter and risk decisions on behalf of the protocol"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "multiplierPointsTagBoost",
-            "docs": [
-              "Reward points multiplier per obligation type"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          },
-          {
-            "name": "elevationGroups",
-            "docs": [
-              "Elevation groups are used to group together reserves that have the same risk parameters and can bump the ltv and liquidation threshold"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "ElevationGroup"
-                },
-                32
-              ]
-            }
-          },
-          {
-            "name": "elevationGroupPadding",
-            "type": {
-              "array": [
-                "u64",
-                90
-              ]
-            }
-          },
-          {
-            "name": "padding1",
-            "type": {
-              "array": [
-                "u64",
-                180
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Obligation",
-      "docs": [
-        "Lending market obligation state"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tag",
-            "docs": [
-              "Version of the struct"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "lastUpdate",
-            "docs": [
-              "Last update to collateral, liquidity, or their market values"
-            ],
-            "type": {
-              "defined": "LastUpdate"
-            }
-          },
-          {
-            "name": "lendingMarket",
-            "docs": [
-              "Lending market address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "owner",
-            "docs": [
-              "Owner authority which can borrow liquidity"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "deposits",
-            "docs": [
-              "TODO: Does this break the stack size when copied onto the stack, if too big?",
-              "Deposited collateral for the obligation, unique by deposit reserve address"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "ObligationCollateral"
-                },
-                8
-              ]
-            }
-          },
-          {
-            "name": "lowestReserveDepositLtv",
-            "docs": [
-              "Worst LTV for the collaterals backing the loan, represented as a percentage"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "depositedValueSf",
-            "docs": [
-              "Market value of deposits (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "borrows",
-            "docs": [
-              "Borrowed liquidity for the obligation, unique by borrow reserve address"
-            ],
-            "type": {
-              "array": [
-                {
-                  "defined": "ObligationLiquidity"
-                },
-                5
-              ]
-            }
-          },
-          {
-            "name": "borrowFactorAdjustedDebtValueSf",
-            "docs": [
-              "Risk adjusted market value of borrows/debt (sum of price * borrowed_amount * borrow_factor) (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "borrowedAssetsMarketValueSf",
-            "docs": [
-              "Market value of borrows - used for max_liquidatable_borrowed_amount (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "allowedBorrowValueSf",
-            "docs": [
-              "The maximum borrow value at the weighted average loan to value ratio (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "unhealthyBorrowValueSf",
-            "docs": [
-              "The dangerous borrow value at the weighted average liquidation threshold (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "depositsAssetTiers",
-            "docs": [
-              "The asset tier of the deposits"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          },
-          {
-            "name": "borrowsAssetTiers",
-            "docs": [
-              "The asset tier of the borrows"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                5
-              ]
-            }
-          },
-          {
-            "name": "elevationGroup",
-            "docs": [
-              "The elevation group id the obligation opted into."
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "referrer",
-            "docs": [
-              "Wallet address of the referrer"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding3",
-            "type": {
-              "array": [
-                "u64",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReferrerTokenState",
-      "docs": [
-        "Referrer account -> each owner can have multiple accounts for specific reserves"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "referrer",
-            "docs": [
-              "Pubkey of the referrer/owner"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "mint",
-            "docs": [
-              "Token mint for the account"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "amountUnclaimedSf",
-            "docs": [
-              "Amount that has been accumulated and not claimed yet -> available to claim (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "amountCumulativeSf",
-            "docs": [
-              "Amount that has been accumulated in total -> both already claimed and unclaimed (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "bump",
-            "docs": [
-              "Referrer token state bump, used for address validation"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                31
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "UserMetadata",
-      "docs": [
-        "Referrer account -> each owner can have multiple accounts for specific reserves"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "referrer",
-            "docs": [
-              "Pubkey of the referrer/owner - pubkey::default if no referrer"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bump",
-            "docs": [
-              "Bump used for validation of account address"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "userLookupTable",
-            "docs": [
-              "User lookup table - used to store all user accounts - atas for each reserve mint, each obligation PDA, UserMetadata itself and all referrer_token_states if there is a referrer"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding1",
-            "type": {
-              "array": [
-                "u64",
-                55
-              ]
-            }
-          },
-          {
-            "name": "padding2",
-            "type": {
-              "array": [
-                "u64",
-                64
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReferrerState",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "shortUrl",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ShortUrl",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "referrer",
-            "type": "publicKey"
-          },
-          {
-            "name": "shortUrl",
-            "type": "string"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Reserve",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "version",
-            "docs": [
-              "Version of the reserve"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "lastUpdate",
-            "docs": [
-              "Last slot when supply and rates updated"
-            ],
-            "type": {
-              "defined": "LastUpdate"
-            }
-          },
-          {
-            "name": "lendingMarket",
-            "docs": [
-              "Lending market address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "farmCollateral",
-            "type": "publicKey"
-          },
-          {
-            "name": "farmDebt",
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidity",
-            "docs": [
-              "Reserve liquidity"
-            ],
-            "type": {
-              "defined": "ReserveLiquidity"
-            }
-          },
-          {
-            "name": "reserveLiquidityPadding",
-            "type": {
-              "array": [
-                "u64",
-                150
-              ]
-            }
-          },
-          {
-            "name": "collateral",
-            "docs": [
-              "Reserve collateral"
-            ],
-            "type": {
-              "defined": "ReserveCollateral"
-            }
-          },
-          {
-            "name": "reserveCollateralPadding",
-            "type": {
-              "array": [
-                "u64",
-                150
-              ]
-            }
-          },
-          {
-            "name": "config",
-            "docs": [
-              "Reserve configuration values"
-            ],
-            "type": {
-              "defined": "ReserveConfig"
-            }
-          },
-          {
-            "name": "configPadding",
-            "type": {
-              "array": [
-                "u64",
-                150
-              ]
-            }
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                240
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "LastUpdate",
-      "docs": [
-        "Last update state"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slot",
-            "docs": [
-              "Last slot when updated"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "stale",
-            "docs": [
-              "True when marked stale, false when slot updated"
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "placeholder",
-            "type": {
-              "array": [
-                "u8",
-                7
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ElevationGroup",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "maxLiquidationBonusBps",
-            "type": "u16"
-          },
-          {
-            "name": "id",
-            "type": "u8"
-          },
-          {
-            "name": "ltvPct",
-            "type": "u8"
-          },
-          {
-            "name": "liquidationThresholdPct",
-            "type": "u8"
-          },
-          {
-            "name": "allowNewLoans",
-            "type": "u8"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                8
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "InitObligationArgs",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tag",
-            "type": "u8"
-          },
-          {
-            "name": "id",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ObligationCollateral",
-      "docs": [
-        "Obligation collateral state"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "depositReserve",
-            "docs": [
-              "Reserve collateral is deposited to"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "depositedAmount",
-            "docs": [
-              "Amount of collateral deposited"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "marketValueSf",
-            "docs": [
-              "Collateral market value in quote currency (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                10
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ObligationLiquidity",
-      "docs": [
-        "Obligation liquidity state"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "borrowReserve",
-            "docs": [
-              "Reserve liquidity is borrowed from"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "cumulativeBorrowRateBsf",
-            "docs": [
-              "Borrow rate used for calculating interest (big scaled fraction)"
-            ],
-            "type": {
-              "defined": "BigFractionBytes"
-            }
-          },
-          {
-            "name": "padding",
-            "type": "u64"
-          },
-          {
-            "name": "borrowedAmountSf",
-            "docs": [
-              "Amount of liquidity borrowed plus interest (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "marketValueSf",
-            "docs": [
-              "Liquidity market value in quote currency (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "borrowFactorAdjustedMarketValueSf",
-            "docs": [
-              "Risk adjusted liquidity market value in quote currency - DEBUG ONLY - use market_value instead"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "padding2",
-            "type": {
-              "array": [
-                "u64",
-                8
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "BigFractionBytes",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "value",
-            "type": {
-              "array": [
-                "u64",
-                4
-              ]
-            }
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                2
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReserveLiquidity",
-      "docs": [
-        "Reserve liquidity"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mintPubkey",
-            "docs": [
-              "Reserve liquidity mint address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "supplyVault",
-            "docs": [
-              "Reserve liquidity supply address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "feeVault",
-            "docs": [
-              "Reserve liquidity fee collection address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "availableAmount",
-            "docs": [
-              "Reserve liquidity available"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "borrowedAmountSf",
-            "docs": [
-              "Reserve liquidity borrowed (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "marketPriceSf",
-            "docs": [
-              "Reserve liquidity market price in quote currency (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "marketPriceLastUpdatedTs",
-            "docs": [
-              "Unix timestamp of the market price (from the oracle)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "mintDecimals",
-            "docs": [
-              "Reserve liquidity mint decimals"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "depositLimitCrossedSlot",
-            "docs": [
-              "Timestamp in slots when the last refresh reserve detected that the liquidity amount is above the deposit cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
-              "If the threshold is not crossed, then the timestamp is set to 0"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "borrowLimitCrossedSlot",
-            "docs": [
-              "Timestamp in slots when the last refresh reserve detected that the borrowed amount is above the borrow cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
-              "If the threshold is not crossed, then the timestamp is set to 0"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "cumulativeBorrowRateBsf",
-            "docs": [
-              "Reserve liquidity cumulative borrow rate (scaled fraction)"
-            ],
-            "type": {
-              "defined": "BigFractionBytes"
-            }
-          },
-          {
-            "name": "accumulatedProtocolFeesSf",
-            "docs": [
-              "Reserve cumulative protocol fees (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "accumulatedReferrerFeesSf",
-            "docs": [
-              "Reserve cumulative referrer fees (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "pendingReferrerFeesSf",
-            "docs": [
-              "Reserve pending referrer fees, to be claimed in refresh_obligation by referrer or protocol (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "absoluteReferralRateSf",
-            "docs": [
-              "Reserve referrer fee absolute rate calculated at each refresh_reserve operation (scaled fraction)"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "padding2",
-            "type": {
-              "array": [
-                "u64",
-                55
-              ]
-            }
-          },
-          {
-            "name": "padding3",
-            "type": {
-              "array": [
-                "u128",
-                32
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReserveCollateral",
-      "docs": [
-        "Reserve collateral"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mintPubkey",
-            "docs": [
-              "Reserve collateral mint address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "mintTotalSupply",
-            "docs": [
-              "Reserve collateral mint supply, used for exchange rate"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "supplyVault",
-            "docs": [
-              "Reserve collateral supply address"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding1",
-            "type": {
-              "array": [
-                "u128",
-                32
-              ]
-            }
-          },
-          {
-            "name": "padding2",
-            "type": {
-              "array": [
-                "u128",
-                32
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReserveConfig",
-      "docs": [
-        "Reserve configuration values"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "status",
-            "docs": [
-              "Status of the reserve Active/Obsolete"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "assetTier",
-            "docs": [
-              "Asset tier -> 0 - regular (collateral & debt), 1 - isolated collateral, 2 - isolated debt"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "reserved0",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "multiplierSideBoost",
-            "docs": [
-              "Boost for side (debt or collateral)"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "multiplierTagBoost",
-            "docs": [
-              "Reward points multiplier per obligation type"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          },
-          {
-            "name": "protocolTakeRatePct",
-            "docs": [
-              "Protocol take rate is the amount borrowed interest protocol receives, as a percentage"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "protocolLiquidationFeePct",
-            "docs": [
-              "Cut of the liquidation bonus that the protocol receives, as a percentage"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "loanToValuePct",
-            "docs": [
-              "Target ratio of the value of borrows to deposits, as a percentage",
-              "0 if use as collateral is disabled"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "liquidationThresholdPct",
-            "docs": [
-              "Loan to value ratio at which an obligation can be liquidated, as percentage"
-            ],
-            "type": "u8"
-          },
-          {
-            "name": "minLiquidationBonusBps",
-            "docs": [
-              "Minimum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "maxLiquidationBonusBps",
-            "docs": [
-              "Maximum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "badDebtLiquidationBonusBps",
-            "docs": [
-              "Bad debt liquidation bonus for an undercollateralized obligation, as bps"
-            ],
-            "type": "u16"
-          },
-          {
-            "name": "deleveragingMarginCallPeriodSecs",
-            "docs": [
-              "Time in seconds that must pass before redemptions are enabled after the deposit limit is crossed"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "deleveragingThresholdSlotsPerBps",
-            "docs": [
-              "The rate at which the deleveraging threshold decreases in slots per bps",
-              "e.g. 1 bps per hour would be 7200 slots per bps (assuming 2 slots per second)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "fees",
-            "docs": [
-              "Program owner fees assessed, separate from gains due to interest accrual"
-            ],
-            "type": {
-              "defined": "ReserveFees"
-            }
-          },
-          {
-            "name": "borrowRateCurve",
-            "docs": [
-              "Borrow rate curve based on utilization"
-            ],
-            "type": {
-              "defined": "BorrowRateCurve"
-            }
-          },
-          {
-            "name": "borrowFactorPct",
-            "docs": [
-              "Borrow factor in percentage - used for risk adjustment"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "depositLimit",
-            "docs": [
-              "Maximum deposit limit of liquidity in native units, u64::MAX for inf"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "borrowLimit",
-            "docs": [
-              "Maximum amount borrowed, u64::MAX for inf, 0 to disable borrows (protected deposits)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tokenInfo",
-            "docs": [
-              "Token id from TokenInfos struct"
-            ],
-            "type": {
-              "defined": "TokenInfo"
-            }
-          },
-          {
-            "name": "depositWithdrawalCap",
-            "docs": [
-              "Deposit withdrawl caps - deposit & redeem"
-            ],
-            "type": {
-              "defined": "WithdrawalCaps"
-            }
-          },
-          {
-            "name": "debtWithdrawalCap",
-            "docs": [
-              "Debt withdrawl caps - borrow & repay"
-            ],
-            "type": {
-              "defined": "WithdrawalCaps"
-            }
-          },
-          {
-            "name": "elevationGroups",
-            "type": {
-              "array": [
-                "u8",
-                20
-              ]
-            }
-          },
-          {
-            "name": "reserved1",
-            "type": {
-              "array": [
-                "u8",
-                4
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "WithdrawalCaps",
-      "docs": [
-        "Reserve Withdrawal Caps State"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "configCapacity",
-            "type": "i64"
-          },
-          {
-            "name": "currentTotal",
-            "type": "i64"
-          },
-          {
-            "name": "lastIntervalStartTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "configIntervalLengthSeconds",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReserveFees",
-      "docs": [
-        "Additional fee information on a reserve",
-        "",
-        "These exist separately from interest accrual fees, and are specifically for the program owner",
-        "and referral fee. The fees are paid out as a percentage of liquidity token amounts during",
-        "repayments and liquidations."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "borrowFeeSf",
-            "docs": [
-              "Fee assessed on `BorrowObligationLiquidity`, as scaled fraction (60 bits fractional part)",
-              "Must be between `0` and `2^60`, such that `2^60 = 1`.  A few examples for",
-              "clarity:",
-              "1% = (1 << 60) / 100 = 11529215046068470",
-              "0.01% (1 basis point) = 115292150460685",
-              "0.00001% (Aave borrow fee) = 115292150461"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "flashLoanFeeSf",
-            "docs": [
-              "Fee for flash loan, expressed as scaled fraction.",
-              "0.3% (Aave flash loan fee) = 0.003 * 2^60 = 3458764513820541"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "docs": [
-              "Used for allignment"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                8
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "name",
-            "docs": [
-              "UTF-8 encoded name of the token (null-terminated)"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "heuristic",
-            "docs": [
-              "Heuristics limits of acceptable price"
-            ],
-            "type": {
-              "defined": "PriceHeuristic"
-            }
-          },
-          {
-            "name": "maxTwapDivergenceBps",
-            "docs": [
-              "Max divergence between twap and price in bps"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "maxAgePriceSeconds",
-            "type": "u64"
-          },
-          {
-            "name": "maxAgeTwapSeconds",
-            "type": "u64"
-          },
-          {
-            "name": "scopeConfiguration",
-            "docs": [
-              "Scope price configuration"
-            ],
-            "type": {
-              "defined": "ScopeConfiguration"
-            }
-          },
-          {
-            "name": "switchboardConfiguration",
-            "docs": [
-              "Switchboard configuration"
-            ],
-            "type": {
-              "defined": "SwitchboardConfiguration"
-            }
-          },
-          {
-            "name": "pythConfiguration",
-            "docs": [
-              "Pyth configuration"
-            ],
-            "type": {
-              "defined": "PythConfiguration"
-            }
-          },
-          {
-            "name": "padding",
-            "type": {
-              "array": [
-                "u64",
-                20
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PriceHeuristic",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lower",
-            "docs": [
-              "Lower value of acceptable price"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "upper",
-            "docs": [
-              "Upper value of acceptable price"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "exp",
-            "docs": [
-              "Number of decimals of the previously defined values"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ScopeConfiguration",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "priceFeed",
-            "docs": [
-              "Pubkey of the scope price feed (disabled if `null` or `default`)"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "priceChain",
-            "docs": [
-              "This is the scope_id price chain that results in a price for the token"
-            ],
-            "type": {
-              "array": [
-                "u16",
-                4
-              ]
-            }
-          },
-          {
-            "name": "twapChain",
-            "docs": [
-              "This is the scope_id price chain for the twap"
-            ],
-            "type": {
-              "array": [
-                "u16",
-                4
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "SwitchboardConfiguration",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "priceAggregator",
-            "docs": [
-              "Pubkey of the base price feed (disabled if `null` or `default`)"
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "twapAggregator",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PythConfiguration",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "price",
-            "docs": [
-              "Pubkey of the base price feed (disabled if `null` or `default`)"
-            ],
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "BorrowRateCurve",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "points",
-            "type": {
-              "array": [
-                {
-                  "defined": "CurvePoint"
-                },
-                11
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "CurvePoint",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "utilizationRateBps",
-            "type": "u32"
-          },
-          {
-            "name": "borrowRateBps",
-            "type": "u32"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LiquidationTokenTest",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Sol"
-          },
-          {
-            "name": "Usdh"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WithdrawalCapAccumulatorAction",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "KeepAccumulator"
-          },
-          {
-            "name": "ResetAccumulator"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReserveFarmKind",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Collateral"
-          },
-          {
-            "name": "Debt"
-          }
-        ]
-      }
-    },
-    {
-      "name": "ReserveStatus",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Active"
-          },
-          {
-            "name": "Obsolete"
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeCalculation",
-      "docs": [
-        "Calculate fees exlusive or inclusive of an amount"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Exclusive"
-          },
-          {
-            "name": "Inclusive"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AssetTier",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Regular"
-          },
-          {
-            "name": "IsolatedCollateral"
-          },
-          {
-            "name": "IsolatedDebt"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UpdateReserveConfigValue",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Bool",
-            "fields": [
-              "bool"
-            ]
-          },
-          {
-            "name": "U8",
-            "fields": [
-              "u8"
-            ]
-          },
-          {
-            "name": "U8Tuple",
-            "fields": [
-              "u8",
-              "u8"
-            ]
-          },
-          {
-            "name": "U16",
-            "fields": [
-              "u16"
-            ]
-          },
-          {
-            "name": "U64",
-            "fields": [
-              "u64"
-            ]
-          },
-          {
-            "name": "Pubkey",
-            "fields": [
-              "publicKey"
-            ]
-          },
-          {
-            "name": "ScopeChain",
-            "fields": [
-              {
-                "array": [
-                  "u16",
-                  4
-                ]
-              }
-            ]
-          },
-          {
-            "name": "Name",
-            "fields": [
-              {
-                "array": [
-                  "u8",
-                  32
-                ]
-              }
-            ]
-          },
-          {
-            "name": "BorrowRateCurve",
-            "fields": [
-              {
-                "defined": "BorrowRateCurve"
-              }
-            ]
-          },
-          {
-            "name": "Full",
-            "fields": [
-              {
-                "defined": "ReserveConfig"
-              }
-            ]
-          },
-          {
-            "name": "WithdrawalCap",
-            "fields": [
-              "u64",
-              "u64"
-            ]
-          },
-          {
-            "name": "ElevationGroups",
-            "fields": [
-              {
-                "array": [
-                  "u8",
-                  20
-                ]
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "UpdateConfigMode",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "UpdateLoanToValuePct"
-          },
-          {
-            "name": "UpdateMaxLiquidationBonusBps"
-          },
-          {
-            "name": "UpdateLiquidationThresholdPct"
-          },
-          {
-            "name": "UpdateProtocolLiquidationFee"
-          },
-          {
-            "name": "UpdateProtocolTakeRate"
-          },
-          {
-            "name": "UpdateFeesBorrowFee"
-          },
-          {
-            "name": "UpdateFeesFlashLoanFee"
-          },
-          {
-            "name": "UpdateFeesReferralFeeBps"
-          },
-          {
-            "name": "UpdateDepositLimit"
-          },
-          {
-            "name": "UpdateBorrowLimit"
-          },
-          {
-            "name": "UpdateTokenInfoLowerHeuristic"
-          },
-          {
-            "name": "UpdateTokenInfoUpperHeuristic"
-          },
-          {
-            "name": "UpdateTokenInfoExpHeuristic"
-          },
-          {
-            "name": "UpdateTokenInfoTwapDivergence"
-          },
-          {
-            "name": "UpdateTokenInfoScopeTwap"
-          },
-          {
-            "name": "UpdateTokenInfoScopeChain"
-          },
-          {
-            "name": "UpdateTokenInfoName"
-          },
-          {
-            "name": "UpdateTokenInfoPriceMaxAge"
-          },
-          {
-            "name": "UpdateTokenInfoTwapMaxAge"
-          },
-          {
-            "name": "UpdateScopePriceFeed"
-          },
-          {
-            "name": "UpdatePythPrice"
-          },
-          {
-            "name": "UpdateSwitchboardFeed"
-          },
-          {
-            "name": "UpdateSwitchboardTwapFeed"
-          },
-          {
-            "name": "UpdateBorrowRateCurve"
-          },
-          {
-            "name": "UpdateEntireReserveConfig"
-          },
-          {
-            "name": "UpdateDebtWithdrawalCap"
-          },
-          {
-            "name": "UpdateDepositWithdrawalCap"
-          },
-          {
-            "name": "UpdateDebtWithdrawalCapCurrentTotal"
-          },
-          {
-            "name": "UpdateDepositWithdrawalCapCurrentTotal"
-          },
-          {
-            "name": "UpdateBadDebtLiquidationBonusBps"
-          },
-          {
-            "name": "UpdateMinLiquidationBonusBps"
-          },
-          {
-            "name": "DeleveragingMarginCallPeriod"
-          },
-          {
-            "name": "UpdateBorrowFactor"
-          },
-          {
-            "name": "UpdateAssetTier"
-          },
-          {
-            "name": "UpdateElevationGroup"
-          },
-          {
-            "name": "DeleveragingThresholdSlotsPerBps"
-          },
-          {
-            "name": "UpdateMultiplierSideBoost"
-          },
-          {
-            "name": "UpdateMultiplierTagBoost"
-          },
-          {
-            "name": "UpdateReserveStatus"
-          }
-        ]
-      }
-    },
-    {
-      "name": "UpdateLendingMarketConfigValue",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Bool",
-            "fields": [
-              "bool"
-            ]
-          },
-          {
-            "name": "U8",
-            "fields": [
-              "u8"
-            ]
-          },
-          {
-            "name": "U8Array",
-            "fields": [
-              {
-                "array": [
-                  "u8",
-                  8
-                ]
-              }
-            ]
-          },
-          {
-            "name": "U16",
-            "fields": [
-              "u16"
-            ]
-          },
-          {
-            "name": "U64",
-            "fields": [
-              "u64"
-            ]
-          },
-          {
-            "name": "Pubkey",
-            "fields": [
-              "publicKey"
-            ]
-          },
-          {
-            "name": "ElevationGroup",
-            "fields": [
-              {
-                "defined": "ElevationGroup"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "UpdateLendingMarketMode",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "UpdateOwner"
-          },
-          {
-            "name": "UpdateEmergencyMode"
-          },
-          {
-            "name": "UpdateLiquidationCloseFactor"
-          },
-          {
-            "name": "UpdateLiquidationMaxValue"
-          },
-          {
-            "name": "UpdateGlobalUnhealthyBorrow"
-          },
-          {
-            "name": "UpdateGlobalAllowedBorrow"
-          },
-          {
-            "name": "UpdateRiskCouncil"
-          },
-          {
-            "name": "UpdateMinFullLiquidationThreshold"
-          },
-          {
-            "name": "UpdateInsolvencyRiskLtv"
-          },
-          {
-            "name": "UpdateElevationGroup"
-          },
-          {
-            "name": "UpdateReferralFeeBps"
-          },
-          {
-            "name": "UpdateMultiplierPoints"
-          },
-          {
-            "name": "UpdatePriceRefreshTriggerToMaxAgePct"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RequiredIxType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "RefreshReserve"
-          },
-          {
-            "name": "RefreshFarmsForObligationForReserve"
-          },
-          {
-            "name": "RefreshObligation"
-          }
-        ]
-      }
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "InvalidMarketAuthority",
-      "msg": "Market authority is invalid"
-    },
-    {
-      "code": 6001,
-      "name": "InvalidMarketOwner",
-      "msg": "Market owner is invalid"
-    },
-    {
-      "code": 6002,
-      "name": "InvalidAccountOwner",
-      "msg": "Input account owner is not the program address"
-    },
-    {
-      "code": 6003,
-      "name": "InvalidAmount",
-      "msg": "Input amount is invalid"
-    },
-    {
-      "code": 6004,
-      "name": "InvalidConfig",
-      "msg": "Input config value is invalid"
-    },
-    {
-      "code": 6005,
-      "name": "InvalidSigner",
-      "msg": "Input account must be a signer"
-    },
-    {
-      "code": 6006,
-      "name": "InvalidAccountInput",
-      "msg": "Invalid account input"
-    },
-    {
-      "code": 6007,
-      "name": "MathOverflow",
-      "msg": "Math operation overflow"
-    },
-    {
-      "code": 6008,
-      "name": "InsufficientLiquidity",
-      "msg": "Insufficient liquidity available"
-    },
-    {
-      "code": 6009,
-      "name": "ReserveStale",
-      "msg": "Reserve state needs to be refreshed"
-    },
-    {
-      "code": 6010,
-      "name": "WithdrawTooSmall",
-      "msg": "Withdraw amount too small"
-    },
-    {
-      "code": 6011,
-      "name": "WithdrawTooLarge",
-      "msg": "Withdraw amount too large"
-    },
-    {
-      "code": 6012,
-      "name": "BorrowTooSmall",
-      "msg": "Borrow amount too small to receive liquidity after fees"
-    },
-    {
-      "code": 6013,
-      "name": "BorrowTooLarge",
-      "msg": "Borrow amount too large for deposited collateral"
-    },
-    {
-      "code": 6014,
-      "name": "RepayTooSmall",
-      "msg": "Repay amount too small to transfer liquidity"
-    },
-    {
-      "code": 6015,
-      "name": "LiquidationTooSmall",
-      "msg": "Liquidation amount too small to receive collateral"
-    },
-    {
-      "code": 6016,
-      "name": "ObligationHealthy",
-      "msg": "Cannot liquidate healthy obligations"
-    },
-    {
-      "code": 6017,
-      "name": "ObligationStale",
-      "msg": "Obligation state needs to be refreshed"
-    },
-    {
-      "code": 6018,
-      "name": "ObligationReserveLimit",
-      "msg": "Obligation reserve limit exceeded"
-    },
-    {
-      "code": 6019,
-      "name": "InvalidObligationOwner",
-      "msg": "Obligation owner is invalid"
-    },
-    {
-      "code": 6020,
-      "name": "ObligationDepositsEmpty",
-      "msg": "Obligation deposits are empty"
-    },
-    {
-      "code": 6021,
-      "name": "ObligationBorrowsEmpty",
-      "msg": "Obligation borrows are empty"
-    },
-    {
-      "code": 6022,
-      "name": "ObligationDepositsZero",
-      "msg": "Obligation deposits have zero value"
-    },
-    {
-      "code": 6023,
-      "name": "ObligationBorrowsZero",
-      "msg": "Obligation borrows have zero value"
-    },
-    {
-      "code": 6024,
-      "name": "InvalidObligationCollateral",
-      "msg": "Invalid obligation collateral"
-    },
-    {
-      "code": 6025,
-      "name": "InvalidObligationLiquidity",
-      "msg": "Invalid obligation liquidity"
-    },
-    {
-      "code": 6026,
-      "name": "ObligationCollateralEmpty",
-      "msg": "Obligation collateral is empty"
-    },
-    {
-      "code": 6027,
-      "name": "ObligationLiquidityEmpty",
-      "msg": "Obligation liquidity is empty"
-    },
-    {
-      "code": 6028,
-      "name": "NegativeInterestRate",
-      "msg": "Interest rate is negative"
-    },
-    {
-      "code": 6029,
-      "name": "InvalidOracleConfig",
-      "msg": "Input oracle config is invalid"
-    },
-    {
-      "code": 6030,
-      "name": "InsufficientProtocolFeesToRedeem",
-      "msg": "Insufficient protocol fees to claim or no liquidity available"
-    },
-    {
-      "code": 6031,
-      "name": "FlashBorrowCpi",
-      "msg": "No cpi flash borrows allowed"
-    },
-    {
-      "code": 6032,
-      "name": "NoFlashRepayFound",
-      "msg": "No corresponding repay found for flash borrow"
-    },
-    {
-      "code": 6033,
-      "name": "InvalidFlashRepay",
-      "msg": "Invalid repay found"
-    },
-    {
-      "code": 6034,
-      "name": "FlashRepayCpi",
-      "msg": "No cpi flash repays allowed"
-    },
-    {
-      "code": 6035,
-      "name": "MultipleFlashBorrows",
-      "msg": "Multiple flash borrows not allowed in the same transaction"
-    },
-    {
-      "code": 6036,
-      "name": "FlashLoansDisabled",
-      "msg": "Flash loans are disabled for this reserve"
-    },
-    {
-      "code": 6037,
-      "name": "SwitchboardV2Error",
-      "msg": "Switchboard error"
-    },
-    {
-      "code": 6038,
-      "name": "CouldNotDeserializeScope",
-      "msg": "Cannot deserialize the scope price account"
-    },
-    {
-      "code": 6039,
-      "name": "PriceTooOld",
-      "msg": "Price too old"
-    },
-    {
-      "code": 6040,
-      "name": "PriceTooDivergentFromTwap",
-      "msg": "Price too divergent from twap"
-    },
-    {
-      "code": 6041,
-      "name": "InvalidTwapPrice",
-      "msg": "Invalid twap price"
-    },
-    {
-      "code": 6042,
-      "name": "GlobalEmergencyMode",
-      "msg": "Emergency mode is enabled"
-    },
-    {
-      "code": 6043,
-      "name": "InvalidFlag",
-      "msg": "Invalid lending market config"
-    },
-    {
-      "code": 6044,
-      "name": "PriceNotValid",
-      "msg": "Price is not valid"
-    },
-    {
-      "code": 6045,
-      "name": "PriceIsBiggerThanHeuristic",
-      "msg": "Price is bigger than allowed by heuristic"
-    },
-    {
-      "code": 6046,
-      "name": "PriceIsLowerThanHeuristic",
-      "msg": "Price lower than allowed by heuristic"
-    },
-    {
-      "code": 6047,
-      "name": "PriceIsZero",
-      "msg": "Price is zero"
-    },
-    {
-      "code": 6048,
-      "name": "PriceConfidenceTooWide",
-      "msg": "Price confidence too wide"
-    },
-    {
-      "code": 6049,
-      "name": "IntegerOverflow",
-      "msg": "Conversion between integers failed"
-    },
-    {
-      "code": 6050,
-      "name": "NoFarmForReserve",
-      "msg": "This reserve does not have a farm"
-    },
-    {
-      "code": 6051,
-      "name": "IncorrectInstructionInPosition",
-      "msg": "Wrong instruction at expected position"
-    },
-    {
-      "code": 6052,
-      "name": "NoPriceFound",
-      "msg": "No price found"
-    },
-    {
-      "code": 6053,
-      "name": "InvalidTwapConfig",
-      "msg": "Invalid Twap configuration: Twap is enabled but one of the enabled price doesn't have a twap"
-    },
-    {
-      "code": 6054,
-      "name": "InvalidPythPriceAccount",
-      "msg": "Pyth price account does not match configuration"
-    },
-    {
-      "code": 6055,
-      "name": "InvalidSwitchboardAccount",
-      "msg": "Switchboard account(s) do not match configuration"
-    },
-    {
-      "code": 6056,
-      "name": "InvalidScopePriceAccount",
-      "msg": "Scope price account does not match configuration"
-    },
-    {
-      "code": 6057,
-      "name": "ObligationCollateralLtvZero",
-      "msg": "The obligation has one collateral with an LTV set to 0. Withdraw it before withdrawing other collaterals"
-    },
-    {
-      "code": 6058,
-      "name": "InvalidObligationSeedsValue",
-      "msg": "Seeds must be default pubkeys for tag 0, and mint addresses for tag 1 or 2"
-    },
-    {
-      "code": 6059,
-      "name": "InvalidObligationId",
-      "msg": "Obligation id must be 0"
-    },
-    {
-      "code": 6060,
-      "name": "InvalidBorrowRateCurvePoint",
-      "msg": "Invalid borrow rate curve point"
-    },
-    {
-      "code": 6061,
-      "name": "InvalidUtilizationRate",
-      "msg": "Invalid utilization rate"
-    },
-    {
-      "code": 6062,
-      "name": "CannotSocializeObligationWithCollateral",
-      "msg": "Obligation hasn't been fully liquidated and debt cannot be socialized."
-    },
-    {
-      "code": 6063,
-      "name": "ObligationEmpty",
-      "msg": "Obligation has no borrows or deposits."
-    },
-    {
-      "code": 6064,
-      "name": "WithdrawalCapReached",
-      "msg": "Withdrawal cap is reached"
-    },
-    {
-      "code": 6065,
-      "name": "LastTimestampGreaterThanCurrent",
-      "msg": "The last interval start timestamp is greater than the current timestamp"
-    },
-    {
-      "code": 6066,
-      "name": "LiquidationSlippageError",
-      "msg": "The reward amount is less than the minimum acceptable received collateral"
-    },
-    {
-      "code": 6067,
-      "name": "IsolatedAssetTierViolation",
-      "msg": "Isolated Asset Tier Violation"
-    },
-    {
-      "code": 6068,
-      "name": "InconsistentElevationGroup",
-      "msg": "The obligation's elevation group and the reserve's are not the same"
-    },
-    {
-      "code": 6069,
-      "name": "InvalidElevationGroup",
-      "msg": "The elevation group chosen for the reserve does not exist in the lending market"
-    },
-    {
-      "code": 6070,
-      "name": "InvalidElevationGroupConfig",
-      "msg": "The elevation group updated has wrong parameters set"
-    },
-    {
-      "code": 6071,
-      "name": "UnhealthyElevationGroupLtv",
-      "msg": "The current obligation must have most or all its debt repaid before changing the elevation group"
-    },
-    {
-      "code": 6072,
-      "name": "ElevationGroupNewLoansDisabled",
-      "msg": "Elevation group does not accept any new loans or any new borrows/withdrawals"
-    },
-    {
-      "code": 6073,
-      "name": "ReserveDeprecated",
-      "msg": "Reserve was deprecated, no longer usable"
-    },
-    {
-      "code": 6074,
-      "name": "ReferrerAccountNotInitialized",
-      "msg": "Referrer account not initialized"
-    },
-    {
-      "code": 6075,
-      "name": "ReferrerAccountMintMissmatch",
-      "msg": "Referrer account mint does not match the operation reserve mint"
-    },
-    {
-      "code": 6076,
-      "name": "ReferrerAccountWrongAddress",
-      "msg": "Referrer account address is not a valid program address"
-    },
-    {
-      "code": 6077,
-      "name": "ReferrerAccountReferrerMissmatch",
-      "msg": "Referrer account referrer does not match the owner referrer"
-    },
-    {
-      "code": 6078,
-      "name": "ReferrerAccountMissing",
-      "msg": "Referrer account missing for obligation with referrer"
-    },
-    {
-      "code": 6079,
-      "name": "InsufficientReferralFeesToRedeem",
-      "msg": "Insufficient referral fees to claim or no liquidity available"
-    },
-    {
-      "code": 6080,
-      "name": "CpiDisabled",
-      "msg": "CPI disabled for this instruction"
-    },
-    {
-      "code": 6081,
-      "name": "ShortUrlNotAsciiAlphanumeric",
-      "msg": "Referrer short_url is not ascii alphanumeric"
-    },
-    {
-      "code": 6082,
-      "name": "ReserveObsolete",
-      "msg": "Reserve is marked as obsolete"
-    }
-  ]
+	"version":"0.1.0",
+	"name":"kamino_lending",
+	"instructions":[
+		{
+			"name":"initLendingMarket",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"quoteCurrency",
+					"type":{
+						"array":[
+							"u8",
+							32
+						]
+					}
+				}
+			]
+		},
+		{
+			"name":"updateLendingMarket",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":true,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"mode",
+					"type":"u64"
+				},
+				{
+					"name":"value",
+					"type":{
+						"array":[
+							"u8",
+							72
+						]
+					}
+				}
+			]
+		},
+		{
+			"name":"updateLendingMarketOwner",
+			"accounts":[
+				{
+					"name":"lendingMarketOwnerCached",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":true,
+					"isSigner":false
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"initReserve",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"feeReceiver",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveCollateralMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveCollateralSupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"liquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"collateralTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"initFarmsForReserve",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"farmsProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"farmsGlobalConfig",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"farmState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"farmsVaultAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"mode",
+					"type":"u8"
+				}
+			]
+		},
+		{
+			"name":"updateReserveConfig",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"mode",
+					"type":"u64"
+				},
+				{
+					"name":"value",
+					"type":"bytes"
+				},
+				{
+					"name":"skipValidation",
+					"type":"bool"
+				}
+			]
+		},
+		{
+			"name":"redeemFees",
+			"accounts":[
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityFeeReceiver",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveSupplyLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"socializeLoss",
+			"accounts":[
+				{
+					"name":"riskCouncil",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"withdrawProtocolFee",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"feeVault",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketOwnerAta",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"amount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"refreshReserve",
+			"accounts":[
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"pythOracle",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"switchboardPriceOracle",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"switchboardTwapOracle",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"scopePrices",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"depositReserveLiquidity",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveCollateralMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"collateralTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"liquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"redeemReserveCollateral",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveCollateralMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"collateralTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"liquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"collateralAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"initObligation",
+			"accounts":[
+				{
+					"name":"obligationOwner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"feePayer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"seed1Account",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"seed2Account",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"ownerUserMetadata",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"args",
+					"type":{
+						"defined":"InitObligationArgs"
+					}
+				}
+			]
+		},
+		{
+			"name":"initObligationFarmsForReserve",
+			"accounts":[
+				{
+					"name":"payer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveFarmState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"obligationFarm",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"farmsProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"mode",
+					"type":"u8"
+				}
+			]
+		},
+		{
+			"name":"refreshObligationFarmsForReserve",
+			"accounts":[
+				{
+					"name":"crank",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserveFarmState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"obligationFarmUserState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"farmsProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"mode",
+					"type":"u8"
+				}
+			]
+		},
+		{
+			"name":"refreshObligation",
+			"accounts":[
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"depositObligationCollateral",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"depositReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveDestinationCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"collateralAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"withdrawObligationCollateral",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveSourceCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"collateralAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"borrowObligationLiquidity",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"borrowReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"borrowReserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"borrowReserveLiquidityFeeReceiver",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerTokenState",
+					"isMut":true,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"repayObligationLiquidity",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"repayReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"depositReserveLiquidityAndObligationCollateral",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveCollateralMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveDestinationDepositCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"placeholderUserDestinationCollateral",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"collateralTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"liquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"withdrawObligationCollateralAndRedeemReserveCollateral",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveSourceCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveCollateralMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"placeholderUserDestinationCollateral",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"collateralTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"liquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"collateralAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"liquidateObligationAndRedeemReserveCollateral",
+			"accounts":[
+				{
+					"name":"liquidator",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"repayReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"repayReserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"repayReserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserveCollateralMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserveCollateralSupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserveLiquiditySupply",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawReserveLiquidityFeeReceiver",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationCollateral",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"collateralTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"repayLiquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"withdrawLiquidityTokenProgram",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"instructionSysvarAccount",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				},
+				{
+					"name":"minAcceptableReceivedLiquidityAmount",
+					"type":"u64"
+				},
+				{
+					"name":"maxAllowedLtvOverridePercent",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"flashRepayReserveLiquidity",
+			"accounts":[
+				{
+					"name":"userTransferAuthority",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityFeeReceiver",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerTokenState",
+					"isMut":true,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"referrerAccount",
+					"isMut":true,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"sysvarInfo",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				},
+				{
+					"name":"borrowInstructionIndex",
+					"type":"u8"
+				}
+			]
+		},
+		{
+			"name":"flashBorrowReserveLiquidity",
+			"accounts":[
+				{
+					"name":"userTransferAuthority",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveSourceLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"userDestinationLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityFeeReceiver",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerTokenState",
+					"isMut":true,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"referrerAccount",
+					"isMut":true,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"sysvarInfo",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"liquidityAmount",
+					"type":"u64"
+				}
+			]
+		},
+		{
+			"name":"requestElevationGroup",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"obligation",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"elevationGroup",
+					"type":"u8"
+				}
+			]
+		},
+		{
+			"name":"initReferrerTokenState",
+			"accounts":[
+				{
+					"name":"payer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"referrerTokenState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"referrer",
+					"type":"publicKey"
+				}
+			]
+		},
+		{
+			"name":"initUserMetadata",
+			"accounts":[
+				{
+					"name":"owner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"feePayer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"userMetadata",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerUserMetadata",
+					"isMut":false,
+					"isSigner":false,
+					"isOptional":true
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"userLookupTable",
+					"type":"publicKey"
+				}
+			]
+		},
+		{
+			"name":"withdrawReferrerFees",
+			"accounts":[
+				{
+					"name":"referrer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"referrerTokenState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveLiquidityMint",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"reserveSupplyLiquidity",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerTokenAccount",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"lendingMarketAuthority",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"tokenProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"initReferrerStateAndShortUrl",
+			"accounts":[
+				{
+					"name":"referrer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"referrerState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerShortUrl",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"referrerUserMetadata",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"shortUrl",
+					"type":"string"
+				}
+			]
+		},
+		{
+			"name":"deleteReferrerStateAndShortUrl",
+			"accounts":[
+				{
+					"name":"referrer",
+					"isMut":true,
+					"isSigner":true
+				},
+				{
+					"name":"referrerState",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"shortUrl",
+					"isMut":true,
+					"isSigner":false
+				},
+				{
+					"name":"rent",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"systemProgram",
+					"isMut":false,
+					"isSigner":false
+				}
+			],
+			"args":[
+				
+			]
+		},
+		{
+			"name":"idlMissingTypes",
+			"accounts":[
+				{
+					"name":"lendingMarketOwner",
+					"isMut":false,
+					"isSigner":true
+				},
+				{
+					"name":"lendingMarket",
+					"isMut":false,
+					"isSigner":false
+				},
+				{
+					"name":"reserve",
+					"isMut":true,
+					"isSigner":false
+				}
+			],
+			"args":[
+				{
+					"name":"reserveFarmKind",
+					"type":{
+						"defined":"ReserveFarmKind"
+					}
+				},
+				{
+					"name":"assetTier",
+					"type":{
+						"defined":"AssetTier"
+					}
+				},
+				{
+					"name":"feeCalculation",
+					"type":{
+						"defined":"FeeCalculation"
+					}
+				},
+				{
+					"name":"reserveStatus",
+					"type":{
+						"defined":"ReserveStatus"
+					}
+				},
+				{
+					"name":"updateConfigMode",
+					"type":{
+						"defined":"UpdateConfigMode"
+					}
+				},
+				{
+					"name":"updateLendingMarketConfigValue",
+					"type":{
+						"defined":"UpdateLendingMarketConfigValue"
+					}
+				},
+				{
+					"name":"updateLendingMarketConfigMode",
+					"type":{
+						"defined":"UpdateLendingMarketMode"
+					}
+				}
+			]
+		}
+	],
+	"accounts":[
+		{
+			"name":"UserState",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"userId",
+						"type":"u64"
+					},
+					{
+						"name":"farmState",
+						"type":"publicKey"
+					},
+					{
+						"name":"owner",
+						"type":"publicKey"
+					},
+					{
+						"name":"isFarmDelegated",
+						"docs":[
+							"Indicate if this user state is part of a delegated farm"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"padding0",
+						"type":{
+							"array":[
+								"u8",
+								7
+							]
+						}
+					},
+					{
+						"name":"rewardsTallyScaled",
+						"docs":[
+							"Rewards tally used for computation of gained rewards",
+							"(scaled from `Decimal` representation)."
+						],
+						"type":{
+							"array":[
+								"u128",
+								10
+							]
+						}
+					},
+					{
+						"name":"rewardsIssuedUnclaimed",
+						"docs":[
+							"Number of reward tokens ready for claim"
+						],
+						"type":{
+							"array":[
+								"u64",
+								10
+							]
+						}
+					},
+					{
+						"name":"lastClaimTs",
+						"type":{
+							"array":[
+								"u64",
+								10
+							]
+						}
+					},
+					{
+						"name":"activeStakeScaled",
+						"docs":[
+							"User stake deposited and usable, generating rewards and fees.",
+							"(scaled from `Decimal` representation)."
+						],
+						"type":"u128"
+					},
+					{
+						"name":"pendingDepositStakeScaled",
+						"docs":[
+							"User stake deposited but not usable and not generating rewards yet.",
+							"(scaled from `Decimal` representation)."
+						],
+						"type":"u128"
+					},
+					{
+						"name":"pendingDepositStakeTs",
+						"docs":[
+							"After this timestamp, pending user stake can be moved to user stake",
+							"Initialized to now() + delayed user stake period"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"pendingWithdrawalUnstakeScaled",
+						"docs":[
+							"User deposits unstaked, pending for withdrawal, not usable and not generating rewards.",
+							"(scaled from `Decimal` representation)."
+						],
+						"type":"u128"
+					},
+					{
+						"name":"pendingWithdrawalUnstakeTs",
+						"docs":[
+							"After this timestamp, user can withdraw their deposit."
+						],
+						"type":"u64"
+					},
+					{
+						"name":"bump",
+						"docs":[
+							"User bump used for account address validation"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"delegatee",
+						"docs":[
+							"Delegatee used for initialisation - useful to check against"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"lastStakeTs",
+						"type":"u64"
+					},
+					{
+						"name":"padding1",
+						"type":{
+							"array":[
+								"u64",
+								50
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"LendingMarket",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"version",
+						"docs":[
+							"Version of lending market"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"bumpSeed",
+						"docs":[
+							"Bump seed for derived authority address"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"lendingMarketOwner",
+						"docs":[
+							"Owner authority which can add new reserves"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"lendingMarketOwnerCached",
+						"docs":[
+							"Temporary cache of the lending market owner, used in update_lending_market_owner"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"quoteCurrency",
+						"docs":[
+							"Currency market prices are quoted in",
+							"e.g. \"USD\" null padded (`*b\"USD\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\"`) or a SPL token mint pubkey"
+						],
+						"type":{
+							"array":[
+								"u8",
+								32
+							]
+						}
+					},
+					{
+						"name":"referralFeeBps",
+						"docs":[
+							"Referral fee for the lending market, as bps out of the total protocol fee"
+						],
+						"type":"u16"
+					},
+					{
+						"name":"emergencyMode",
+						"type":"u8"
+					},
+					{
+						"name":"autodeleverageEnabled",
+						"type":"u8"
+					},
+					{
+						"name":"borrowDisabled",
+						"type":"u8"
+					},
+					{
+						"name":"priceRefreshTriggerToMaxAgePct",
+						"docs":[
+							"Refresh price from oracle only if it's older than this percentage of the price max age.",
+							"e.g. if the max age is set to 100s and this is set to 80%, the price will be refreshed if it's older than 80s.",
+							"Price is always refreshed if this set to 0."
+						],
+						"type":"u8"
+					},
+					{
+						"name":"liquidationMaxDebtCloseFactorPct",
+						"docs":[
+							"Percentage of the total borrowed value in an obligation available for liquidation"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"insolvencyRiskUnhealthyLtvPct",
+						"docs":[
+							"Minimum acceptable unhealthy LTV before max_debt_close_factor_pct becomes 100%"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"minFullLiquidationValueThreshold",
+						"docs":[
+							"Minimum liquidation value threshold triggering full liquidation for an obligation"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"maxLiquidatableDebtMarketValueAtOnce",
+						"docs":[
+							"Max allowed liquidation value in one ix call"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"globalUnhealthyBorrowValue",
+						"docs":[
+							"Global maximum unhealthy borrow value allowed for any obligation"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"globalAllowedBorrowValue",
+						"docs":[
+							"Global maximum allowed borrow value allowed for any obligation"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"riskCouncil",
+						"docs":[
+							"The address of the risk council, in charge of making parameter and risk decisions on behalf of the protocol"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"multiplierPointsTagBoost",
+						"docs":[
+							"Reward points multiplier per obligation type"
+						],
+						"type":{
+							"array":[
+								"u8",
+								8
+							]
+						}
+					},
+					{
+						"name":"elevationGroups",
+						"docs":[
+							"Elevation groups are used to group together reserves that have the same risk parameters and can bump the ltv and liquidation threshold"
+						],
+						"type":{
+							"array":[
+								{
+									"defined":"ElevationGroup"
+								},
+								32
+							]
+						}
+					},
+					{
+						"name":"elevationGroupPadding",
+						"type":{
+							"array":[
+								"u64",
+								90
+							]
+						}
+					},
+					{
+						"name":"minNetValueInObligationSf",
+						"docs":[
+							"Min net value accepted to be found in a position after any lending action in an obligation (scaled by quote currency decimals)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"minValueSkipLiquidationLtvBfChecks",
+						"type":"u64"
+					},
+					{
+						"name":"padding1",
+						"type":{
+							"array":[
+								"u64",
+								177
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"Obligation",
+			"docs":[
+				"Lending market obligation state"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"tag",
+						"docs":[
+							"Version of the struct"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"lastUpdate",
+						"docs":[
+							"Last update to collateral, liquidity, or their market values"
+						],
+						"type":{
+							"defined":"LastUpdate"
+						}
+					},
+					{
+						"name":"lendingMarket",
+						"docs":[
+							"Lending market address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"owner",
+						"docs":[
+							"Owner authority which can borrow liquidity"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"deposits",
+						"docs":[
+							"TODO: Does this break the stack size when copied onto the stack, if too big?",
+							"Deposited collateral for the obligation, unique by deposit reserve address"
+						],
+						"type":{
+							"array":[
+								{
+									"defined":"ObligationCollateral"
+								},
+								8
+							]
+						}
+					},
+					{
+						"name":"lowestReserveDepositLiquidationLtv",
+						"docs":[
+							"Worst LTV for the collaterals backing the loan, represented as a percentage"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"depositedValueSf",
+						"docs":[
+							"Market value of deposits (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"borrows",
+						"docs":[
+							"Borrowed liquidity for the obligation, unique by borrow reserve address"
+						],
+						"type":{
+							"array":[
+								{
+									"defined":"ObligationLiquidity"
+								},
+								5
+							]
+						}
+					},
+					{
+						"name":"borrowFactorAdjustedDebtValueSf",
+						"docs":[
+							"Risk adjusted market value of borrows/debt (sum of price * borrowed_amount * borrow_factor) (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"borrowedAssetsMarketValueSf",
+						"docs":[
+							"Market value of borrows - used for max_liquidatable_borrowed_amount (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"allowedBorrowValueSf",
+						"docs":[
+							"The maximum borrow value at the weighted average loan to value ratio (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"unhealthyBorrowValueSf",
+						"docs":[
+							"The dangerous borrow value at the weighted average liquidation threshold (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"depositsAssetTiers",
+						"docs":[
+							"The asset tier of the deposits"
+						],
+						"type":{
+							"array":[
+								"u8",
+								8
+							]
+						}
+					},
+					{
+						"name":"borrowsAssetTiers",
+						"docs":[
+							"The asset tier of the borrows"
+						],
+						"type":{
+							"array":[
+								"u8",
+								5
+							]
+						}
+					},
+					{
+						"name":"elevationGroup",
+						"docs":[
+							"The elevation group id the obligation opted into."
+						],
+						"type":"u8"
+					},
+					{
+						"name":"numOfObsoleteReserves",
+						"docs":[
+							"The number of deprecated reserves the obligation has a deposit"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"hasDebt",
+						"docs":[
+							"Marked = 1 if borrows array is not empty, 0 = borrows empty"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"referrer",
+						"docs":[
+							"Wallet address of the referrer"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"borrowingDisabled",
+						"docs":[
+							"Marked = 1 if borrowing disabled, 0 = borrowing enabled"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"reserved",
+						"type":{
+							"array":[
+								"u8",
+								7
+							]
+						}
+					},
+					{
+						"name":"highestBorrowFactorPct",
+						"type":"u64"
+					},
+					{
+						"name":"padding3",
+						"type":{
+							"array":[
+								"u64",
+								126
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ReferrerState",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"shortUrl",
+						"type":"publicKey"
+					},
+					{
+						"name":"owner",
+						"type":"publicKey"
+					}
+				]
+			}
+		},
+		{
+			"name":"ReferrerTokenState",
+			"docs":[
+				"Referrer account -> each owner can have multiple accounts for specific reserves"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"referrer",
+						"docs":[
+							"Pubkey of the referrer/owner"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"mint",
+						"docs":[
+							"Token mint for the account"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"amountUnclaimedSf",
+						"docs":[
+							"Amount that has been accumulated and not claimed yet -> available to claim (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"amountCumulativeSf",
+						"docs":[
+							"Amount that has been accumulated in total -> both already claimed and unclaimed (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"bump",
+						"docs":[
+							"Referrer token state bump, used for address validation"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"padding",
+						"type":{
+							"array":[
+								"u64",
+								31
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ShortUrl",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"referrer",
+						"type":"publicKey"
+					},
+					{
+						"name":"shortUrl",
+						"type":"string"
+					}
+				]
+			}
+		},
+		{
+			"name":"UserMetadata",
+			"docs":[
+				"Referrer account -> each owner can have multiple accounts for specific reserves"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"referrer",
+						"docs":[
+							"Pubkey of the referrer/owner - pubkey::default if no referrer"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"bump",
+						"docs":[
+							"Bump used for validation of account address"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"userLookupTable",
+						"docs":[
+							"User lookup table - used to store all user accounts - atas for each reserve mint, each obligation PDA, UserMetadata itself and all referrer_token_states if there is a referrer"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"owner",
+						"docs":[
+							"User metadata account owner"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"padding1",
+						"type":{
+							"array":[
+								"u64",
+								51
+							]
+						}
+					},
+					{
+						"name":"padding2",
+						"type":{
+							"array":[
+								"u64",
+								64
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"Reserve",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"version",
+						"docs":[
+							"Version of the reserve"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"lastUpdate",
+						"docs":[
+							"Last slot when supply and rates updated"
+						],
+						"type":{
+							"defined":"LastUpdate"
+						}
+					},
+					{
+						"name":"lendingMarket",
+						"docs":[
+							"Lending market address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"farmCollateral",
+						"type":"publicKey"
+					},
+					{
+						"name":"farmDebt",
+						"type":"publicKey"
+					},
+					{
+						"name":"liquidity",
+						"docs":[
+							"Reserve liquidity"
+						],
+						"type":{
+							"defined":"ReserveLiquidity"
+						}
+					},
+					{
+						"name":"reserveLiquidityPadding",
+						"type":{
+							"array":[
+								"u64",
+								150
+							]
+						}
+					},
+					{
+						"name":"collateral",
+						"docs":[
+							"Reserve collateral"
+						],
+						"type":{
+							"defined":"ReserveCollateral"
+						}
+					},
+					{
+						"name":"reserveCollateralPadding",
+						"type":{
+							"array":[
+								"u64",
+								150
+							]
+						}
+					},
+					{
+						"name":"config",
+						"docs":[
+							"Reserve configuration values"
+						],
+						"type":{
+							"defined":"ReserveConfig"
+						}
+					},
+					{
+						"name":"configPadding",
+						"type":{
+							"array":[
+								"u64",
+								117
+							]
+						}
+					},
+					{
+						"name":"borrowedAmountOutsideElevationGroup",
+						"type":"u64"
+					},
+					{
+						"name":"borrowedAmountsAgainstThisReserveInElevationGroups",
+						"docs":[
+							"Amount of token borrowed in lamport of debt asset in the given",
+							"elevation group when this reserve is part of the collaterals."
+						],
+						"type":{
+							"array":[
+								"u64",
+								32
+							]
+						}
+					},
+					{
+						"name":"padding",
+						"type":{
+							"array":[
+								"u64",
+								207
+							]
+						}
+					}
+				]
+			}
+		}
+	],
+	"types":[
+		{
+			"name":"UpdateConfigMode",
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"UpdateLoanToValuePct"
+					},
+					{
+						"name":"UpdateMaxLiquidationBonusBps"
+					},
+					{
+						"name":"UpdateLiquidationThresholdPct"
+					},
+					{
+						"name":"UpdateProtocolLiquidationFee"
+					},
+					{
+						"name":"UpdateProtocolTakeRate"
+					},
+					{
+						"name":"UpdateFeesBorrowFee"
+					},
+					{
+						"name":"UpdateFeesFlashLoanFee"
+					},
+					{
+						"name":"UpdateFeesReferralFeeBps"
+					},
+					{
+						"name":"UpdateDepositLimit"
+					},
+					{
+						"name":"UpdateBorrowLimit"
+					},
+					{
+						"name":"UpdateTokenInfoLowerHeuristic"
+					},
+					{
+						"name":"UpdateTokenInfoUpperHeuristic"
+					},
+					{
+						"name":"UpdateTokenInfoExpHeuristic"
+					},
+					{
+						"name":"UpdateTokenInfoTwapDivergence"
+					},
+					{
+						"name":"UpdateTokenInfoScopeTwap"
+					},
+					{
+						"name":"UpdateTokenInfoScopeChain"
+					},
+					{
+						"name":"UpdateTokenInfoName"
+					},
+					{
+						"name":"UpdateTokenInfoPriceMaxAge"
+					},
+					{
+						"name":"UpdateTokenInfoTwapMaxAge"
+					},
+					{
+						"name":"UpdateScopePriceFeed"
+					},
+					{
+						"name":"UpdatePythPrice"
+					},
+					{
+						"name":"UpdateSwitchboardFeed"
+					},
+					{
+						"name":"UpdateSwitchboardTwapFeed"
+					},
+					{
+						"name":"UpdateBorrowRateCurve"
+					},
+					{
+						"name":"UpdateEntireReserveConfig"
+					},
+					{
+						"name":"UpdateDebtWithdrawalCap"
+					},
+					{
+						"name":"UpdateDepositWithdrawalCap"
+					},
+					{
+						"name":"UpdateDebtWithdrawalCapCurrentTotal"
+					},
+					{
+						"name":"UpdateDepositWithdrawalCapCurrentTotal"
+					},
+					{
+						"name":"UpdateBadDebtLiquidationBonusBps"
+					},
+					{
+						"name":"UpdateMinLiquidationBonusBps"
+					},
+					{
+						"name":"DeleveragingMarginCallPeriod"
+					},
+					{
+						"name":"UpdateBorrowFactor"
+					},
+					{
+						"name":"UpdateAssetTier"
+					},
+					{
+						"name":"UpdateElevationGroup"
+					},
+					{
+						"name":"DeleveragingThresholdSlotsPerBps"
+					},
+					{
+						"name":"UpdateMultiplierSideBoost"
+					},
+					{
+						"name":"UpdateMultiplierTagBoost"
+					},
+					{
+						"name":"UpdateReserveStatus"
+					},
+					{
+						"name":"UpdateFarmCollateral"
+					},
+					{
+						"name":"UpdateFarmDebt"
+					},
+					{
+						"name":"UpdateDisableUsageAsCollateralOutsideEmode"
+					},
+					{
+						"name":"UpdateBlockBorrowingAboveUtilization"
+					},
+					{
+						"name":"UpdateBlockPriceUsage"
+					},
+					{
+						"name":"UpdateBorrowLimitOutsideElevationGroup"
+					},
+					{
+						"name":"UpdateBorrowLimitsInElevationGroupAgainstThisReserve"
+					},
+					{
+						"name":"UpdateHostFixedInterestRateBps"
+					}
+				]
+			}
+		},
+		{
+			"name":"UpdateLendingMarketConfigValue",
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"Bool",
+						"fields":[
+							"bool"
+						]
+					},
+					{
+						"name":"U8",
+						"fields":[
+							"u8"
+						]
+					},
+					{
+						"name":"U8Array",
+						"fields":[
+							{
+								"array":[
+									"u8",
+									8
+								]
+							}
+						]
+					},
+					{
+						"name":"U16",
+						"fields":[
+							"u16"
+						]
+					},
+					{
+						"name":"U64",
+						"fields":[
+							"u64"
+						]
+					},
+					{
+						"name":"U128",
+						"fields":[
+							"u128"
+						]
+					},
+					{
+						"name":"Pubkey",
+						"fields":[
+							"publicKey"
+						]
+					},
+					{
+						"name":"ElevationGroup",
+						"fields":[
+							{
+								"defined":"ElevationGroup"
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"name":"UpdateLendingMarketMode",
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"UpdateOwner"
+					},
+					{
+						"name":"UpdateEmergencyMode"
+					},
+					{
+						"name":"UpdateLiquidationCloseFactor"
+					},
+					{
+						"name":"UpdateLiquidationMaxValue"
+					},
+					{
+						"name":"UpdateGlobalUnhealthyBorrow"
+					},
+					{
+						"name":"UpdateGlobalAllowedBorrow"
+					},
+					{
+						"name":"UpdateRiskCouncil"
+					},
+					{
+						"name":"UpdateMinFullLiquidationThreshold"
+					},
+					{
+						"name":"UpdateInsolvencyRiskLtv"
+					},
+					{
+						"name":"UpdateElevationGroup"
+					},
+					{
+						"name":"UpdateReferralFeeBps"
+					},
+					{
+						"name":"UpdateMultiplierPoints"
+					},
+					{
+						"name":"UpdatePriceRefreshTriggerToMaxAgePct"
+					},
+					{
+						"name":"UpdateAutodeleverageEnabled"
+					},
+					{
+						"name":"UpdateBorrowingDisabled"
+					},
+					{
+						"name":"UpdateMinNetValueObligationPostAction"
+					},
+					{
+						"name":"UpdateMinValueSkipPriorityLiqCheck"
+					}
+				]
+			}
+		},
+		{
+			"name":"LastUpdate",
+			"docs":[
+				"Last update state"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"slot",
+						"docs":[
+							"Last slot when updated"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"stale",
+						"docs":[
+							"True when marked stale, false when slot updated"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"priceStatus",
+						"docs":[
+							"Status of the prices used to calculate the last update"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"placeholder",
+						"type":{
+							"array":[
+								"u8",
+								6
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ElevationGroup",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"maxLiquidationBonusBps",
+						"type":"u16"
+					},
+					{
+						"name":"id",
+						"type":"u8"
+					},
+					{
+						"name":"ltvPct",
+						"type":"u8"
+					},
+					{
+						"name":"liquidationThresholdPct",
+						"type":"u8"
+					},
+					{
+						"name":"allowNewLoans",
+						"type":"u8"
+					},
+					{
+						"name":"maxReservesAsCollateral",
+						"type":"u8"
+					},
+					{
+						"name":"padding0",
+						"type":"u8"
+					},
+					{
+						"name":"debtReserve",
+						"docs":[
+							"Mandatory debt reserve for this elevation group"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"padding1",
+						"type":{
+							"array":[
+								"u64",
+								4
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"InitObligationArgs",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"tag",
+						"type":"u8"
+					},
+					{
+						"name":"id",
+						"type":"u8"
+					}
+				]
+			}
+		},
+		{
+			"name":"ObligationCollateral",
+			"docs":[
+				"Obligation collateral state"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"depositReserve",
+						"docs":[
+							"Reserve collateral is deposited to"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"depositedAmount",
+						"docs":[
+							"Amount of collateral deposited"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"marketValueSf",
+						"docs":[
+							"Collateral market value in quote currency (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"borrowedAmountAgainstThisCollateralInElevationGroup",
+						"docs":[
+							"Debt amount (lamport) taken against this collateral.",
+							"(only meaningful if this obligation is part of an elevation group, otherwise 0)",
+							"This is only indicative of the debt computed on the last refresh obligation.",
+							"If the obligation have multiple collateral this value is the same for all of them."
+						],
+						"type":"u64"
+					},
+					{
+						"name":"padding",
+						"type":{
+							"array":[
+								"u64",
+								9
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ObligationLiquidity",
+			"docs":[
+				"Obligation liquidity state"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"borrowReserve",
+						"docs":[
+							"Reserve liquidity is borrowed from"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"cumulativeBorrowRateBsf",
+						"docs":[
+							"Borrow rate used for calculating interest (big scaled fraction)"
+						],
+						"type":{
+							"defined":"BigFractionBytes"
+						}
+					},
+					{
+						"name":"padding",
+						"type":"u64"
+					},
+					{
+						"name":"borrowedAmountSf",
+						"docs":[
+							"Amount of liquidity borrowed plus interest (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"marketValueSf",
+						"docs":[
+							"Liquidity market value in quote currency (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"borrowFactorAdjustedMarketValueSf",
+						"docs":[
+							"Risk adjusted liquidity market value in quote currency - DEBUG ONLY - use market_value instead"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"borrowedAmountOutsideElevationGroups",
+						"docs":[
+							"Amount of liquidity borrowed outside of an elevation group"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"padding2",
+						"type":{
+							"array":[
+								"u64",
+								7
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"AssetTier",
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"Regular"
+					},
+					{
+						"name":"IsolatedCollateral"
+					},
+					{
+						"name":"IsolatedDebt"
+					}
+				]
+			}
+		},
+		{
+			"name":"BigFractionBytes",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"value",
+						"type":{
+							"array":[
+								"u64",
+								4
+							]
+						}
+					},
+					{
+						"name":"padding",
+						"type":{
+							"array":[
+								"u64",
+								2
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"FeeCalculation",
+			"docs":[
+				"Calculate fees exlusive or inclusive of an amount"
+			],
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"Exclusive"
+					},
+					{
+						"name":"Inclusive"
+					}
+				]
+			}
+		},
+		{
+			"name":"ReserveCollateral",
+			"docs":[
+				"Reserve collateral"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"mintPubkey",
+						"docs":[
+							"Reserve collateral mint address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"mintTotalSupply",
+						"docs":[
+							"Reserve collateral mint supply, used for exchange rate"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"supplyVault",
+						"docs":[
+							"Reserve collateral supply address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"padding1",
+						"type":{
+							"array":[
+								"u128",
+								32
+							]
+						}
+					},
+					{
+						"name":"padding2",
+						"type":{
+							"array":[
+								"u128",
+								32
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ReserveConfig",
+			"docs":[
+				"Reserve configuration values"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"status",
+						"docs":[
+							"Status of the reserve Active/Obsolete/Hidden"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"assetTier",
+						"docs":[
+							"Asset tier -> 0 - regular (collateral & debt), 1 - isolated collateral, 2 - isolated debt"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"hostFixedInterestRateBps",
+						"docs":[
+							"Flat rate that goes to the host"
+						],
+						"type":"u16"
+					},
+					{
+						"name":"multiplierSideBoost",
+						"docs":[
+							"Boost for side (debt or collateral)"
+						],
+						"type":{
+							"array":[
+								"u8",
+								2
+							]
+						}
+					},
+					{
+						"name":"multiplierTagBoost",
+						"docs":[
+							"Reward points multiplier per obligation type"
+						],
+						"type":{
+							"array":[
+								"u8",
+								8
+							]
+						}
+					},
+					{
+						"name":"protocolTakeRatePct",
+						"docs":[
+							"Protocol take rate is the amount borrowed interest protocol receives, as a percentage"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"protocolLiquidationFeePct",
+						"docs":[
+							"Cut of the liquidation bonus that the protocol receives, as a percentage"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"loanToValuePct",
+						"docs":[
+							"Target ratio of the value of borrows to deposits, as a percentage",
+							"0 if use as collateral is disabled"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"liquidationThresholdPct",
+						"docs":[
+							"Loan to value ratio at which an obligation can be liquidated, as percentage"
+						],
+						"type":"u8"
+					},
+					{
+						"name":"minLiquidationBonusBps",
+						"docs":[
+							"Minimum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
+						],
+						"type":"u16"
+					},
+					{
+						"name":"maxLiquidationBonusBps",
+						"docs":[
+							"Maximum bonus a liquidator receives when repaying part of an unhealthy obligation, as bps"
+						],
+						"type":"u16"
+					},
+					{
+						"name":"badDebtLiquidationBonusBps",
+						"docs":[
+							"Bad debt liquidation bonus for an undercollateralized obligation, as bps"
+						],
+						"type":"u16"
+					},
+					{
+						"name":"deleveragingMarginCallPeriodSecs",
+						"docs":[
+							"Time in seconds that must pass before redemptions are enabled after the deposit limit is crossed"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"deleveragingThresholdSlotsPerBps",
+						"docs":[
+							"The rate at which the deleveraging threshold decreases in slots per bps",
+							"e.g. 1 bps per hour would be 7200 slots per bps (assuming 2 slots per second)"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"fees",
+						"docs":[
+							"Program owner fees assessed, separate from gains due to interest accrual"
+						],
+						"type":{
+							"defined":"ReserveFees"
+						}
+					},
+					{
+						"name":"borrowRateCurve",
+						"docs":[
+							"Borrow rate curve based on utilization"
+						],
+						"type":{
+							"defined":"BorrowRateCurve"
+						}
+					},
+					{
+						"name":"borrowFactorPct",
+						"docs":[
+							"Borrow factor in percentage - used for risk adjustment"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"depositLimit",
+						"docs":[
+							"Maximum deposit limit of liquidity in native units, u64::MAX for inf"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"borrowLimit",
+						"docs":[
+							"Maximum amount borrowed, u64::MAX for inf, 0 to disable borrows (protected deposits)"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"tokenInfo",
+						"docs":[
+							"Token id from TokenInfos struct"
+						],
+						"type":{
+							"defined":"TokenInfo"
+						}
+					},
+					{
+						"name":"depositWithdrawalCap",
+						"docs":[
+							"Deposit withdrawl caps - deposit & redeem"
+						],
+						"type":{
+							"defined":"WithdrawalCaps"
+						}
+					},
+					{
+						"name":"debtWithdrawalCap",
+						"docs":[
+							"Debt withdrawl caps - borrow & repay"
+						],
+						"type":{
+							"defined":"WithdrawalCaps"
+						}
+					},
+					{
+						"name":"elevationGroups",
+						"type":{
+							"array":[
+								"u8",
+								20
+							]
+						}
+					},
+					{
+						"name":"disableUsageAsCollOutsideEmode",
+						"type":"u8"
+					},
+					{
+						"name":"utilizationLimitBlockBorrowingAbove",
+						"type":"u8"
+					},
+					{
+						"name":"reserved1",
+						"type":{
+							"array":[
+								"u8",
+								2
+							]
+						}
+					},
+					{
+						"name":"borrowLimitOutsideElevationGroup",
+						"docs":[
+							"Maximum amount liquidity of this reserve borrowed outside all elevation groups",
+							"- u64::MAX for inf",
+							"- 0 to disable borrows outside elevation groups"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"borrowLimitAgainstThisCollateralInElevationGroup",
+						"docs":[
+							"Defines the maximum amount (in lamports of elevation group debt asset)",
+							"that can be borrowed when this reserve is used as collateral.",
+							"- u64::MAX for inf",
+							"- 0 to disable borrows in this elevation group (expected value for the debt asset)"
+						],
+						"type":{
+							"array":[
+								"u64",
+								32
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ReserveFarmKind",
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"Collateral"
+					},
+					{
+						"name":"Debt"
+					}
+				]
+			}
+		},
+		{
+			"name":"ReserveFees",
+			"docs":[
+				"Additional fee information on a reserve",
+				"",
+				"These exist separately from interest accrual fees, and are specifically for the program owner",
+				"and referral fee. The fees are paid out as a percentage of liquidity token amounts during",
+				"repayments and liquidations."
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"borrowFeeSf",
+						"docs":[
+							"Fee assessed on `BorrowObligationLiquidity`, as scaled fraction (60 bits fractional part)",
+							"Must be between `0` and `2^60`, such that `2^60 = 1`.  A few examples for",
+							"clarity:",
+							"1% = (1 << 60) / 100 = 11529215046068470",
+							"0.01% (1 basis point) = 115292150460685",
+							"0.00001% (Aave borrow fee) = 115292150461"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"flashLoanFeeSf",
+						"docs":[
+							"Fee for flash loan, expressed as scaled fraction.",
+							"0.3% (Aave flash loan fee) = 0.003 * 2^60 = 3458764513820541"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"padding",
+						"docs":[
+							"Used for allignment"
+						],
+						"type":{
+							"array":[
+								"u8",
+								8
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ReserveLiquidity",
+			"docs":[
+				"Reserve liquidity"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"mintPubkey",
+						"docs":[
+							"Reserve liquidity mint address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"supplyVault",
+						"docs":[
+							"Reserve liquidity supply address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"feeVault",
+						"docs":[
+							"Reserve liquidity fee collection address"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"availableAmount",
+						"docs":[
+							"Reserve liquidity available"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"borrowedAmountSf",
+						"docs":[
+							"Reserve liquidity borrowed (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"marketPriceSf",
+						"docs":[
+							"Reserve liquidity market price in quote currency (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"marketPriceLastUpdatedTs",
+						"docs":[
+							"Unix timestamp of the market price (from the oracle)"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"mintDecimals",
+						"docs":[
+							"Reserve liquidity mint decimals"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"depositLimitCrossedSlot",
+						"docs":[
+							"Timestamp in slots when the last refresh reserve detected that the liquidity amount is above the deposit cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
+							"If the threshold is not crossed, then the timestamp is set to 0"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"borrowLimitCrossedSlot",
+						"docs":[
+							"Timestamp in slots when the last refresh reserve detected that the borrowed amount is above the borrow cap. When this threshold is crossed, then redemptions (auto-deleverage) are enabled.",
+							"If the threshold is not crossed, then the timestamp is set to 0"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"cumulativeBorrowRateBsf",
+						"docs":[
+							"Reserve liquidity cumulative borrow rate (scaled fraction)"
+						],
+						"type":{
+							"defined":"BigFractionBytes"
+						}
+					},
+					{
+						"name":"accumulatedProtocolFeesSf",
+						"docs":[
+							"Reserve cumulative protocol fees (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"accumulatedReferrerFeesSf",
+						"docs":[
+							"Reserve cumulative referrer fees (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"pendingReferrerFeesSf",
+						"docs":[
+							"Reserve pending referrer fees, to be claimed in refresh_obligation by referrer or protocol (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"absoluteReferralRateSf",
+						"docs":[
+							"Reserve referrer fee absolute rate calculated at each refresh_reserve operation (scaled fraction)"
+						],
+						"type":"u128"
+					},
+					{
+						"name":"tokenProgram",
+						"docs":[
+							"Token program of the liquidity mint"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"padding2",
+						"type":{
+							"array":[
+								"u64",
+								51
+							]
+						}
+					},
+					{
+						"name":"padding3",
+						"type":{
+							"array":[
+								"u128",
+								32
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"ReserveStatus",
+			"type":{
+				"kind":"enum",
+				"variants":[
+					{
+						"name":"Active"
+					},
+					{
+						"name":"Obsolete"
+					},
+					{
+						"name":"Hidden"
+					}
+				]
+			}
+		},
+		{
+			"name":"WithdrawalCaps",
+			"docs":[
+				"Reserve Withdrawal Caps State"
+			],
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"configCapacity",
+						"type":"i64"
+					},
+					{
+						"name":"currentTotal",
+						"type":"i64"
+					},
+					{
+						"name":"lastIntervalStartTimestamp",
+						"type":"u64"
+					},
+					{
+						"name":"configIntervalLengthSeconds",
+						"type":"u64"
+					}
+				]
+			}
+		},
+		{
+			"name":"PriceHeuristic",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"lower",
+						"docs":[
+							"Lower value of acceptable price"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"upper",
+						"docs":[
+							"Upper value of acceptable price"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"exp",
+						"docs":[
+							"Number of decimals of the previously defined values"
+						],
+						"type":"u64"
+					}
+				]
+			}
+		},
+		{
+			"name":"PythConfiguration",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"price",
+						"docs":[
+							"Pubkey of the base price feed (disabled if `null` or `default`)"
+						],
+						"type":"publicKey"
+					}
+				]
+			}
+		},
+		{
+			"name":"ScopeConfiguration",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"priceFeed",
+						"docs":[
+							"Pubkey of the scope price feed (disabled if `null` or `default`)"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"priceChain",
+						"docs":[
+							"This is the scope_id price chain that results in a price for the token"
+						],
+						"type":{
+							"array":[
+								"u16",
+								4
+							]
+						}
+					},
+					{
+						"name":"twapChain",
+						"docs":[
+							"This is the scope_id price chain for the twap"
+						],
+						"type":{
+							"array":[
+								"u16",
+								4
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"SwitchboardConfiguration",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"priceAggregator",
+						"docs":[
+							"Pubkey of the base price feed (disabled if `null` or `default`)"
+						],
+						"type":"publicKey"
+					},
+					{
+						"name":"twapAggregator",
+						"type":"publicKey"
+					}
+				]
+			}
+		},
+		{
+			"name":"TokenInfo",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"name",
+						"docs":[
+							"UTF-8 encoded name of the token (null-terminated)"
+						],
+						"type":{
+							"array":[
+								"u8",
+								32
+							]
+						}
+					},
+					{
+						"name":"heuristic",
+						"docs":[
+							"Heuristics limits of acceptable price"
+						],
+						"type":{
+							"defined":"PriceHeuristic"
+						}
+					},
+					{
+						"name":"maxTwapDivergenceBps",
+						"docs":[
+							"Max divergence between twap and price in bps"
+						],
+						"type":"u64"
+					},
+					{
+						"name":"maxAgePriceSeconds",
+						"type":"u64"
+					},
+					{
+						"name":"maxAgeTwapSeconds",
+						"type":"u64"
+					},
+					{
+						"name":"scopeConfiguration",
+						"docs":[
+							"Scope price configuration"
+						],
+						"type":{
+							"defined":"ScopeConfiguration"
+						}
+					},
+					{
+						"name":"switchboardConfiguration",
+						"docs":[
+							"Switchboard configuration"
+						],
+						"type":{
+							"defined":"SwitchboardConfiguration"
+						}
+					},
+					{
+						"name":"pythConfiguration",
+						"docs":[
+							"Pyth configuration"
+						],
+						"type":{
+							"defined":"PythConfiguration"
+						}
+					},
+					{
+						"name":"blockPriceUsage",
+						"type":"u8"
+					},
+					{
+						"name":"reserved",
+						"type":{
+							"array":[
+								"u8",
+								7
+							]
+						}
+					},
+					{
+						"name":"padding",
+						"type":{
+							"array":[
+								"u64",
+								19
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"BorrowRateCurve",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"points",
+						"type":{
+							"array":[
+								{
+									"defined":"CurvePoint"
+								},
+								11
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			"name":"CurvePoint",
+			"type":{
+				"kind":"struct",
+				"fields":[
+					{
+						"name":"utilizationRateBps",
+						"type":"u32"
+					},
+					{
+						"name":"borrowRateBps",
+						"type":"u32"
+					}
+				]
+			}
+		}
+	],
+	"errors":[
+		{
+			"code":6000,
+			"name":"InvalidMarketAuthority",
+			"msg":"Market authority is invalid"
+		},
+		{
+			"code":6001,
+			"name":"InvalidMarketOwner",
+			"msg":"Market owner is invalid"
+		},
+		{
+			"code":6002,
+			"name":"InvalidAccountOwner",
+			"msg":"Input account owner is not the program address"
+		},
+		{
+			"code":6003,
+			"name":"InvalidAmount",
+			"msg":"Input amount is invalid"
+		},
+		{
+			"code":6004,
+			"name":"InvalidConfig",
+			"msg":"Input config value is invalid"
+		},
+		{
+			"code":6005,
+			"name":"InvalidSigner",
+			"msg":"Input account must be a signer"
+		},
+		{
+			"code":6006,
+			"name":"InvalidAccountInput",
+			"msg":"Invalid account input"
+		},
+		{
+			"code":6007,
+			"name":"MathOverflow",
+			"msg":"Math operation overflow"
+		},
+		{
+			"code":6008,
+			"name":"InsufficientLiquidity",
+			"msg":"Insufficient liquidity available"
+		},
+		{
+			"code":6009,
+			"name":"ReserveStale",
+			"msg":"Reserve state needs to be refreshed"
+		},
+		{
+			"code":6010,
+			"name":"WithdrawTooSmall",
+			"msg":"Withdraw amount too small"
+		},
+		{
+			"code":6011,
+			"name":"WithdrawTooLarge",
+			"msg":"Withdraw amount too large"
+		},
+		{
+			"code":6012,
+			"name":"BorrowTooSmall",
+			"msg":"Borrow amount too small to receive liquidity after fees"
+		},
+		{
+			"code":6013,
+			"name":"BorrowTooLarge",
+			"msg":"Borrow amount too large for deposited collateral"
+		},
+		{
+			"code":6014,
+			"name":"RepayTooSmall",
+			"msg":"Repay amount too small to transfer liquidity"
+		},
+		{
+			"code":6015,
+			"name":"LiquidationTooSmall",
+			"msg":"Liquidation amount too small to receive collateral"
+		},
+		{
+			"code":6016,
+			"name":"ObligationHealthy",
+			"msg":"Cannot liquidate healthy obligations"
+		},
+		{
+			"code":6017,
+			"name":"ObligationStale",
+			"msg":"Obligation state needs to be refreshed"
+		},
+		{
+			"code":6018,
+			"name":"ObligationReserveLimit",
+			"msg":"Obligation reserve limit exceeded"
+		},
+		{
+			"code":6019,
+			"name":"InvalidObligationOwner",
+			"msg":"Obligation owner is invalid"
+		},
+		{
+			"code":6020,
+			"name":"ObligationDepositsEmpty",
+			"msg":"Obligation deposits are empty"
+		},
+		{
+			"code":6021,
+			"name":"ObligationBorrowsEmpty",
+			"msg":"Obligation borrows are empty"
+		},
+		{
+			"code":6022,
+			"name":"ObligationDepositsZero",
+			"msg":"Obligation deposits have zero value"
+		},
+		{
+			"code":6023,
+			"name":"ObligationBorrowsZero",
+			"msg":"Obligation borrows have zero value"
+		},
+		{
+			"code":6024,
+			"name":"InvalidObligationCollateral",
+			"msg":"Invalid obligation collateral"
+		},
+		{
+			"code":6025,
+			"name":"InvalidObligationLiquidity",
+			"msg":"Invalid obligation liquidity"
+		},
+		{
+			"code":6026,
+			"name":"ObligationCollateralEmpty",
+			"msg":"Obligation collateral is empty"
+		},
+		{
+			"code":6027,
+			"name":"ObligationLiquidityEmpty",
+			"msg":"Obligation liquidity is empty"
+		},
+		{
+			"code":6028,
+			"name":"NegativeInterestRate",
+			"msg":"Interest rate is negative"
+		},
+		{
+			"code":6029,
+			"name":"InvalidOracleConfig",
+			"msg":"Input oracle config is invalid"
+		},
+		{
+			"code":6030,
+			"name":"InsufficientProtocolFeesToRedeem",
+			"msg":"Insufficient protocol fees to claim or no liquidity available"
+		},
+		{
+			"code":6031,
+			"name":"FlashBorrowCpi",
+			"msg":"No cpi flash borrows allowed"
+		},
+		{
+			"code":6032,
+			"name":"NoFlashRepayFound",
+			"msg":"No corresponding repay found for flash borrow"
+		},
+		{
+			"code":6033,
+			"name":"InvalidFlashRepay",
+			"msg":"Invalid repay found"
+		},
+		{
+			"code":6034,
+			"name":"FlashRepayCpi",
+			"msg":"No cpi flash repays allowed"
+		},
+		{
+			"code":6035,
+			"name":"MultipleFlashBorrows",
+			"msg":"Multiple flash borrows not allowed in the same transaction"
+		},
+		{
+			"code":6036,
+			"name":"FlashLoansDisabled",
+			"msg":"Flash loans are disabled for this reserve"
+		},
+		{
+			"code":6037,
+			"name":"SwitchboardV2Error",
+			"msg":"Switchboard error"
+		},
+		{
+			"code":6038,
+			"name":"CouldNotDeserializeScope",
+			"msg":"Cannot deserialize the scope price account"
+		},
+		{
+			"code":6039,
+			"name":"PriceTooOld",
+			"msg":"Price too old"
+		},
+		{
+			"code":6040,
+			"name":"PriceTooDivergentFromTwap",
+			"msg":"Price too divergent from twap"
+		},
+		{
+			"code":6041,
+			"name":"InvalidTwapPrice",
+			"msg":"Invalid twap price"
+		},
+		{
+			"code":6042,
+			"name":"GlobalEmergencyMode",
+			"msg":"Emergency mode is enabled"
+		},
+		{
+			"code":6043,
+			"name":"InvalidFlag",
+			"msg":"Invalid lending market config"
+		},
+		{
+			"code":6044,
+			"name":"PriceNotValid",
+			"msg":"Price is not valid"
+		},
+		{
+			"code":6045,
+			"name":"PriceIsBiggerThanHeuristic",
+			"msg":"Price is bigger than allowed by heuristic"
+		},
+		{
+			"code":6046,
+			"name":"PriceIsLowerThanHeuristic",
+			"msg":"Price lower than allowed by heuristic"
+		},
+		{
+			"code":6047,
+			"name":"PriceIsZero",
+			"msg":"Price is zero"
+		},
+		{
+			"code":6048,
+			"name":"PriceConfidenceTooWide",
+			"msg":"Price confidence too wide"
+		},
+		{
+			"code":6049,
+			"name":"IntegerOverflow",
+			"msg":"Conversion between integers failed"
+		},
+		{
+			"code":6050,
+			"name":"NoFarmForReserve",
+			"msg":"This reserve does not have a farm"
+		},
+		{
+			"code":6051,
+			"name":"IncorrectInstructionInPosition",
+			"msg":"Wrong instruction at expected position"
+		},
+		{
+			"code":6052,
+			"name":"NoPriceFound",
+			"msg":"No price found"
+		},
+		{
+			"code":6053,
+			"name":"InvalidTwapConfig",
+			"msg":"Invalid Twap configuration: Twap is enabled but one of the enabled price doesn't have a twap"
+		},
+		{
+			"code":6054,
+			"name":"InvalidPythPriceAccount",
+			"msg":"Pyth price account does not match configuration"
+		},
+		{
+			"code":6055,
+			"name":"InvalidSwitchboardAccount",
+			"msg":"Switchboard account(s) do not match configuration"
+		},
+		{
+			"code":6056,
+			"name":"InvalidScopePriceAccount",
+			"msg":"Scope price account does not match configuration"
+		},
+		{
+			"code":6057,
+			"name":"ObligationCollateralLtvZero",
+			"msg":"The obligation has one collateral with an LTV set to 0. Withdraw it before withdrawing other collaterals"
+		},
+		{
+			"code":6058,
+			"name":"InvalidObligationSeedsValue",
+			"msg":"Seeds must be default pubkeys for tag 0, and mint addresses for tag 1 or 2"
+		},
+		{
+			"code":6059,
+			"name":"InvalidObligationId",
+			"msg":"Obligation id must be 0"
+		},
+		{
+			"code":6060,
+			"name":"InvalidBorrowRateCurvePoint",
+			"msg":"Invalid borrow rate curve point"
+		},
+		{
+			"code":6061,
+			"name":"InvalidUtilizationRate",
+			"msg":"Invalid utilization rate"
+		},
+		{
+			"code":6062,
+			"name":"CannotSocializeObligationWithCollateral",
+			"msg":"Obligation hasn't been fully liquidated and debt cannot be socialized."
+		},
+		{
+			"code":6063,
+			"name":"ObligationEmpty",
+			"msg":"Obligation has no borrows or deposits."
+		},
+		{
+			"code":6064,
+			"name":"WithdrawalCapReached",
+			"msg":"Withdrawal cap is reached"
+		},
+		{
+			"code":6065,
+			"name":"LastTimestampGreaterThanCurrent",
+			"msg":"The last interval start timestamp is greater than the current timestamp"
+		},
+		{
+			"code":6066,
+			"name":"LiquidationRewardTooSmall",
+			"msg":"The reward amount is less than the minimum acceptable received liquidity"
+		},
+		{
+			"code":6067,
+			"name":"IsolatedAssetTierViolation",
+			"msg":"Isolated Asset Tier Violation"
+		},
+		{
+			"code":6068,
+			"name":"InconsistentElevationGroup",
+			"msg":"The obligation's elevation group and the reserve's are not the same"
+		},
+		{
+			"code":6069,
+			"name":"InvalidElevationGroup",
+			"msg":"The elevation group chosen for the reserve does not exist in the lending market"
+		},
+		{
+			"code":6070,
+			"name":"InvalidElevationGroupConfig",
+			"msg":"The elevation group updated has wrong parameters set"
+		},
+		{
+			"code":6071,
+			"name":"UnhealthyElevationGroupLtv",
+			"msg":"The current obligation must have most or all its debt repaid before changing the elevation group"
+		},
+		{
+			"code":6072,
+			"name":"ElevationGroupNewLoansDisabled",
+			"msg":"Elevation group does not accept any new loans or any new borrows/withdrawals"
+		},
+		{
+			"code":6073,
+			"name":"ReserveDeprecated",
+			"msg":"Reserve was deprecated, no longer usable"
+		},
+		{
+			"code":6074,
+			"name":"ReferrerAccountNotInitialized",
+			"msg":"Referrer account not initialized"
+		},
+		{
+			"code":6075,
+			"name":"ReferrerAccountMintMissmatch",
+			"msg":"Referrer account mint does not match the operation reserve mint"
+		},
+		{
+			"code":6076,
+			"name":"ReferrerAccountWrongAddress",
+			"msg":"Referrer account address is not a valid program address"
+		},
+		{
+			"code":6077,
+			"name":"ReferrerAccountReferrerMissmatch",
+			"msg":"Referrer account referrer does not match the owner referrer"
+		},
+		{
+			"code":6078,
+			"name":"ReferrerAccountMissing",
+			"msg":"Referrer account missing for obligation with referrer"
+		},
+		{
+			"code":6079,
+			"name":"InsufficientReferralFeesToRedeem",
+			"msg":"Insufficient referral fees to claim or no liquidity available"
+		},
+		{
+			"code":6080,
+			"name":"CpiDisabled",
+			"msg":"CPI disabled for this instruction"
+		},
+		{
+			"code":6081,
+			"name":"ShortUrlNotAsciiAlphanumeric",
+			"msg":"Referrer short_url is not ascii alphanumeric"
+		},
+		{
+			"code":6082,
+			"name":"ReserveObsolete",
+			"msg":"Reserve is marked as obsolete"
+		},
+		{
+			"code":6083,
+			"name":"ElevationGroupAlreadyActivated",
+			"msg":"Obligation already part of the same elevation group"
+		},
+		{
+			"code":6084,
+			"name":"ObligationInDeprecatedReserve",
+			"msg":"Obligation has a deposit in a deprecated reserve"
+		},
+		{
+			"code":6085,
+			"name":"ReferrerStateOwnerMismatch",
+			"msg":"Referrer state owner does not match the given signer"
+		},
+		{
+			"code":6086,
+			"name":"UserMetadataOwnerAlreadySet",
+			"msg":"User metadata owner is already set"
+		},
+		{
+			"code":6087,
+			"name":"CollateralNonLiquidatable",
+			"msg":"This collateral cannot be liquidated (LTV set to 0)"
+		},
+		{
+			"code":6088,
+			"name":"BorrowingDisabled",
+			"msg":"Borrowing is disabled"
+		},
+		{
+			"code":6089,
+			"name":"BorrowLimitExceeded",
+			"msg":"Cannot borrow above borrow limit"
+		},
+		{
+			"code":6090,
+			"name":"DepositLimitExceeded",
+			"msg":"Cannot deposit above deposit limit"
+		},
+		{
+			"code":6091,
+			"name":"BorrowingDisabledOutsideElevationGroup",
+			"msg":"Reserve does not accept any new borrows outside elevation group"
+		},
+		{
+			"code":6092,
+			"name":"NetValueRemainingTooSmall",
+			"msg":"Net value remaining too small"
+		},
+		{
+			"code":6093,
+			"name":"WorseLTVBlocked",
+			"msg":"Cannot get the obligation in a worse position"
+		},
+		{
+			"code":6094,
+			"name":"LiabilitiesBiggerThanAssets",
+			"msg":"Cannot have more liabilities than assets in a position"
+		},
+		{
+			"code":6095,
+			"name":"ReserveTokenBalanceMismatch",
+			"msg":"Reserve state and token account cannot drift"
+		},
+		{
+			"code":6096,
+			"name":"ReserveVaultBalanceMismatch",
+			"msg":"Reserve token account has been unexpectedly modified"
+		},
+		{
+			"code":6097,
+			"name":"ReserveAccountingMismatch",
+			"msg":"Reserve internal state accounting has been unexpectedly modified"
+		},
+		{
+			"code":6098,
+			"name":"BorrowingAboveUtilizationRateDisabled",
+			"msg":"Borrowing above set utilization rate is disabled"
+		},
+		{
+			"code":6099,
+			"name":"LiquidationBorrowFactorPriority",
+			"msg":"Liquidation must prioritize the debt with the highest borrow factor"
+		},
+		{
+			"code":6100,
+			"name":"LiquidationLowestLTVPriority",
+			"msg":"Liquidation must prioritize the collateral with the lowest LTV"
+		},
+		{
+			"code":6101,
+			"name":"ElevationGroupBorrowLimitExceeded",
+			"msg":"Elevation group borrow limit exceeded"
+		},
+		{
+			"code":6102,
+			"name":"ElevationGroupWithoutDebtReserve",
+			"msg":"The elevation group does not have a debt reserve defined"
+		},
+		{
+			"code":6103,
+			"name":"ElevationGroupMaxCollateralReserveZero",
+			"msg":"The elevation group does not allow any collateral reserves"
+		},
+		{
+			"code":6104,
+			"name":"ElevationGroupHasAnotherDebtReserve",
+			"msg":"In elevation group attempt to borrow from a reserve that is not the debt reserve"
+		},
+		{
+			"code":6105,
+			"name":"ElevationGroupDebtReserveAsCollateral",
+			"msg":"The elevation group's debt reserve cannot be used as a collateral reserve"
+		},
+		{
+			"code":6106,
+			"name":"ObligationCollateralExceedsElevationGroupLimit",
+			"msg":"Obligation have more collateral than the maximum allowed by the elevation group"
+		},
+		{
+			"code":6107,
+			"name":"ObligationElevationGroupMultipleDebtReserve",
+			"msg":"Obligation is an elevation group but have more than one debt reserve"
+		},
+		{
+			"code":6108,
+			"name":"UnsupportedTokenExtension",
+			"msg":"Mint has a token (2022) extension that is not supported"
+		},
+		{
+			"code":6109,
+			"name":"InvalidTokenAccount",
+			"msg":"Can't have an spl token mint with a t22 account"
+		}
+	]
 }


### PR DESCRIPTION
This PR is intended to adapt the library to release 1.6.2, adding new fields for different accounts.

Did not check whether instructions need adapting and have not changed them.

